### PR TITLE
Add GenPareto and ExtGenPareto distributions

### DIFF
--- a/pytensor_distributions/extgenpareto.py
+++ b/pytensor_distributions/extgenpareto.py
@@ -1,0 +1,163 @@
+#   Copyright 2022 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Extended Generalized Pareto distribution (Naveau et al. 2016 Type 1)."""
+
+import numpy as np
+import pytensor.tensor as pt
+
+from pytensor_distributions.genpareto import (
+    _gpd_log_H,
+    _gpd_log_h,
+    _gpd_log_S,
+    _gpd_quantile_from_excess,
+    _gpd_upper_bound,
+    _in_gpd_support,
+    _log1p_div,
+)
+from pytensor_distributions.helper import ppf_bounds_cont
+
+# Extended Generalized Pareto core. Naveau et al. (2016) extended GPD with
+# carrier G(v) = v ** kappa: the CDF is F = H ** kappa with H the GPD CDF, so
+# kappa > 0 reshapes the lower tail while xi keeps controlling the upper tail.
+# kappa = 1 recovers the plain GPD.
+
+
+def logpdf(x, mu, sigma, xi, kappa):
+    z = (x - mu) / sigma
+    # log g = log kappa + (kappa - 1) log H + log h. The carrier term vanishes
+    # at kappa = 1; guarding it keeps the GPD reduction exact at the lower
+    # endpoint (z = 0, log H = -inf), where (kappa - 1) * log H would be 0 * -inf.
+    carrier = pt.switch(pt.eq(kappa, 1.0), 0.0, (kappa - 1) * _gpd_log_H(z, xi))
+    logp = pt.log(kappa) + carrier + _gpd_log_h(z, sigma, xi)
+    logp = pt.switch(_in_gpd_support(z, xi), logp, -np.inf)
+    logp = pt.switch(pt.eq(z, np.inf), -np.inf, logp)
+    return logp
+
+
+def logcdf(x, mu, sigma, xi, kappa):
+    z = (x - mu) / sigma
+    above_upper = pt.and_(pt.lt(xi, 0), pt.le(1 + xi * z, 0))
+    logcdf = pt.switch(above_upper, 0.0, kappa * _gpd_log_H(z, xi))
+    logcdf = pt.switch(z >= 0, logcdf, -np.inf)
+    logcdf = pt.switch(pt.eq(z, np.inf), 0.0, logcdf)
+    return logcdf
+
+
+def logsf(x, mu, sigma, xi, kappa):
+    z = (x - mu) / sigma
+    a = _gpd_log_S(z, xi)  # log(1 - H), accurate in the tail
+    log_H = pt.log1mexp(a)
+    generic = pt.log1mexp(kappa * log_H)
+    s = pt.exp(a)  # S_gpd
+    # r = kappa * S_gpd, formed via exp(log kappa + a) and capped at 1 so the unused
+    # (generic-branch) tail expression cannot overflow.
+    r = pt.exp(pt.minimum(pt.log(kappa) + a, 0.0))
+    # 1 - H**kappa = kappa S [1 + (s - r)/2 + (r**2 - 3 r s + 2 s**2)/6 + ...].
+    # This is a Taylor expansion in *both* S_gpd and kappa*S_gpd, so it is only
+    # valid where both are small; writing it in r = kappa S and s = S keeps every
+    # term bounded (no kappa**k powers, which overflow for huge kappa).
+    series_m1 = (s - r) / 2.0 + (r * r - 3.0 * r * s + 2.0 * s * s) / 6.0
+    tail = pt.log(kappa) + a + pt.log1p(series_m1)
+    # The Taylor tail runs where S_gpd and kappa*S_gpd are both below machine epsilon
+    # (a < log_eps and log(kappa) + a < log_eps); the generic log1mexp(kappa log H) runs
+    # otherwise. Both conditions gate the switch: for tiny kappa the second holds in the body
+    # (S_gpd ~ 1) too, where the Taylor does not apply.
+    log_eps = float(np.log(np.finfo(a.dtype).eps))
+    logsf = pt.switch(pt.and_(a < log_eps, pt.log(kappa) + a < log_eps), tail, generic)
+    above_upper = pt.and_(pt.lt(xi, 0), pt.le(1 + xi * z, 0))
+    logsf = pt.switch(pt.or_(above_upper, pt.eq(z, np.inf)), -np.inf, logsf)
+    logsf = pt.switch(z < 0, 0.0, logsf)
+    return logsf
+
+
+def _ext_gpd_excess_from_log_prob(log_q, kappa):
+    """GPD excess ``m = -log(1 - F ** (1/kappa))`` from ``log_q = log F``.
+
+    For the carrier ``F = H ** kappa``, the GPD CDF is ``H = exp(log_q / kappa)``
+    and its survival ``1 - H``, so ``m = -log(1 - H) = -log1mexp(log_q / kappa)``
+    (``pt.log1mexp(a) = log(1 - exp(a))`` for ``a <= 0``). This form stays accurate when ``H``
+    rounds to ``1``: for small ``kappa`` the survival ``1 - H`` is tiny, and forming it directly
+    would collapse the excess to ``0`` (and the quantile to ``mu``). Shared
+    by the quantile, the sampler, ``support_point`` and the default transform so
+    all four inverses agree. ``log_q`` must be ``<= 0`` (a log-probability).
+    """
+    return -pt.log1mexp(log_q / kappa)
+
+
+def _ext_gpd_excess_from_logit(value, kappa):
+    """GPD excess ``m = -log S(x)`` from ``value = logit(F(x))``.
+
+    The ExtGPD CDF is ``F = G ** kappa = sigmoid(value)`` (``G`` the GPD CDF), so the excess
+    depends only on ``value`` and ``kappa``:
+        m = -log(1 - G) = -log(1 - sigmoid(value) ** (1/kappa)).
+    Evaluated stably in two branches split at a large cutoff. Writing
+    a := -log G = -log(sigmoid(value)) / kappa gives m = -log1mexp(-a):
+      bulk (value < cutoff): m = -log1mexp(log_F / kappa), log_F = log sigmoid(value).
+      tail (value >= cutoff, the extreme upper tail where F -> 1): a held in logs as log_a,
+        m = -log_a where a < eps, else -log1mexp(-a).
+    The unused branch's inputs are clamped (log_F via cutoff, a via log_max) so it stays finite.
+    """
+    finfo = np.finfo(value.dtype)
+    log_max = float(np.log(finfo.max))  # a = exp(min(log_a, log_max)) stays finite
+    log_eps = float(np.log(finfo.eps))  # at or below log_eps, m = -log_a
+    # cutoff is the large value where log_F / kappa reaches finfo.tiny. Near the tail
+    # log_F = -exp(-value), giving value = -log(tiny) - log(kappa); for kappa <= 1 it is -log(tiny).
+    cutoff = np.asarray(-np.log(finfo.tiny), dtype=value.dtype) - pt.maximum(
+        np.asarray(0.0, value.dtype), pt.log(kappa)
+    )
+    t = pt.softplus(value)
+    log_F = -pt.softplus(-pt.minimum(value, cutoff))
+    m_bulk = _ext_gpd_excess_from_log_prob(log_F, kappa)
+    s = pt.exp(-pt.maximum(t, cutoff))  # S_ext, clamped so _log1p_div stays finite
+    log_a = -t + pt.log(_log1p_div(-s)) - pt.log(kappa)
+    a = pt.exp(pt.minimum(log_a, log_max))
+    m_tail = pt.switch(log_a < log_eps, -log_a, -pt.log1mexp(-a))
+    return pt.switch(value < cutoff, m_bulk, m_tail)
+
+
+def ppf(q, mu, sigma, xi, kappa):
+    q = pt.as_tensor_variable(q)
+    # F = H ** kappa = q  ->  H = q ** (1/kappa); excess m = -log(1 - H), built
+    # with log1mexp so a tiny 1 - H (small kappa) is not rounded away to 0.
+    excess = _ext_gpd_excess_from_log_prob(pt.log(q), kappa)
+    x = _gpd_quantile_from_excess(excess, mu, sigma, xi)
+    return ppf_bounds_cont(x, q, mu, _gpd_upper_bound(mu, sigma, xi))
+
+
+def cdf(x, mu, sigma, xi, kappa):
+    return pt.exp(logcdf(x, mu, sigma, xi, kappa))
+
+
+def pdf(x, mu, sigma, xi, kappa):
+    return pt.exp(logpdf(x, mu, sigma, xi, kappa))
+
+
+def sf(x, mu, sigma, xi, kappa):
+    return pt.exp(logsf(x, mu, sigma, xi, kappa))
+
+
+def isf(x, mu, sigma, xi, kappa):
+    x = pt.as_tensor_variable(x)
+    # log F = log1p(-x), accurate for tiny x; ppf(1 - x) forms 1 - x first and loses it.
+    excess = _ext_gpd_excess_from_log_prob(pt.log1p(-x), kappa)
+    quantile = _gpd_quantile_from_excess(excess, mu, sigma, xi)
+    return ppf_bounds_cont(quantile, x, _gpd_upper_bound(mu, sigma, xi), mu)
+
+
+def rvs(mu, sigma, xi, kappa, size=None, random_state=None):
+    # Inverse-CDF on a carrier draw u = F; excess = -log(1 - u ** (1/kappa)).
+    u = pt.random.uniform(size=size, rng=random_state, return_next_rng=True)[1]
+    excess = _ext_gpd_excess_from_log_prob(pt.log(u), kappa)
+    return _gpd_quantile_from_excess(excess, mu, sigma, xi)

--- a/pytensor_distributions/extgenpareto.py
+++ b/pytensor_distributions/extgenpareto.py
@@ -1,19 +1,3 @@
-#   Copyright 2022 The PyMC Developers
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
-
-"""Extended Generalized Pareto distribution (Naveau et al. 2016 Type 1)."""
-
 import numpy as np
 import pytensor.tensor as pt
 from pytensor.tensor.special import betaln
@@ -249,7 +233,7 @@ def entropy(mu, sigma, xi, kappa):
         - pt.log(kappa)
         + 1
         - 1 / kappa
-        + (1 + xi) * (pt.psi(kappa + 1) + np.euler_gamma)
+        + (1 + xi) * (pt.psi(kappa + 1) + pt.euler_gamma)
     )
 
 

--- a/pytensor_distributions/extgenpareto.py
+++ b/pytensor_distributions/extgenpareto.py
@@ -1,3 +1,5 @@
+from math import comb, factorial
+
 import numpy as np
 import pytensor.tensor as pt
 from pytensor.tensor.special import betaln
@@ -163,13 +165,15 @@ def rvs(mu, sigma, xi, kappa, size=None, random_state=None):
     return _gpd_quantile_from_excess(excess, mu, sigma, xi)
 
 
-# Summary statistics. With the substitution x = mu + (sigma/xi)(W ** (-xi) - 1),
-# W ~ Beta(1, kappa), the power moments reduce to Beta functions:
-#   E[W ** (-j xi)] = kappa * B(1 - j xi, kappa),
-# finite (like the plain GPD) only for j xi < 1, so each moment is guarded. The
-# exponential-tail limit xi -> 0 is a 0/0 in those Beta forms, so each statistic switches
-# to its closed-form digamma/polygamma limit there; ``_safe_xi`` keeps the discarded
-# branch finite so its gradient is not poisoned.
+# Summary statistics. With x = mu + (sigma/xi)(W ** (-xi) - 1), W ~ Beta(1, kappa), the
+# r-th central moment is sigma ** r times q_r = E[((W ** (-xi) - 1)/xi - mean) ** r]. Its
+# exact Beta-function form is finite (like the plain GPD) only for r xi < 1 -- hence the
+# guards -- and cancels catastrophically as xi -> 0. q_r is one function of the order r:
+# near xi = 0 a Taylor series in xi (the same idea as _log1p_div / _expm1_div), the exact
+# Beta combination otherwise. The series coefficients are generic in r -- joint central
+# moments of L = -log(W), each tamed by a 1/(n!) factor so the factorial growth of the raw
+# moments does not spoil convergence -- built from L's cumulants
+#   kappa_k = (-1) ** (k - 1) [psi ** (k - 1)(kappa + 1) - psi ** (k - 1)(1)].
 
 
 def _pow_moment(j, xi, kappa):
@@ -188,23 +192,129 @@ def _safe_xi(xi):
     return pt.switch(pt.eq(xi, 0.0), 0.1, xi)
 
 
+_MOMENT_SERIES_TERMS = 8  # Taylor order m = 0..8 in xi.
+_MOMENT_SERIES_CUTOFF = 1.8e-2  # |xi| below which the series beats the cancelling exact form.
+
+# polygamma(d, 1) = (-1) ** (d + 1) * d! * zeta(d + 1), for d = 0..11. Baked as literals
+# because pytensor#2244 makes ``pt.polygamma(d, 1.0)`` (a constant argument) ~1e-9 inaccurate;
+# the runtime path ``pt.polygamma(d, kappa + 1)`` for a *symbolic* argument is exact.
+_POLYGAMMA_AT_ONE = (
+    -0.5772156649015329,
+    1.6449340668482266,
+    -2.404113806319188,
+    6.493939402266829,
+    -24.88626612344089,
+    122.08116743813386,
+    -726.0114797149845,
+    5060.549875237641,
+    -40400.97839874765,
+    363240.9114223827,
+    -3630593.3116066284,
+    39926622.98773108,
+)
+
+
+def _neglogw_raw_moments(kappa):
+    """Raw moments ``mu_0 .. mu_{TERMS + 4}`` of ``L = -log(W)``, ``W ~ Beta(1, kappa)``.
+
+    Built once from L's cumulants (polygamma) via the moment-cumulant recursion and shared
+    across every moment order.
+    """
+    n_max = _MOMENT_SERIES_TERMS + 4
+    cumulants = []
+    for k in range(1, n_max + 1):
+        d = k - 1
+        poly_kappa = pt.psi(kappa + 1) if d == 0 else pt.polygamma(d, kappa + 1)
+        cumulants.append((-1.0) ** d * (poly_kappa - _POLYGAMMA_AT_ONE[d]))
+    raw = [pt.ones_like(kappa)]
+    for n in range(1, n_max + 1):
+        raw.append(sum(comb(n - 1, i) * cumulants[n - 1 - i] * raw[i] for i in range(n)))
+    return raw
+
+
+def _partitions(total, parts):
+    """Non-increasing tuples of ``parts`` positive integers summing to ``total``."""
+    if parts == 1:
+        if total >= 1:
+            yield (total,)
+        return
+    for first in range(total - parts + 1, 0, -1):
+        for rest in _partitions(total - first, parts - 1):
+            if rest[0] <= first:
+                yield (first, *rest)
+
+
+def _ordering_count(partition):
+    """How many distinct orderings ``partition`` has (its multinomial coefficient)."""
+    count = factorial(len(partition))
+    for value in set(partition):
+        count //= factorial(partition.count(value))
+    return count
+
+
+def _joint_central_moment(orders, raw):
+    """Joint central moment ``E[prod_i (L ** o_i - mu_{o_i})]`` by subset inclusion-exclusion."""
+    r = len(orders)
+    total = 0.0
+    for mask in range(1 << r):
+        kept = sum(orders[i] for i in range(r) if mask >> i & 1)
+        term = raw[kept]
+        for i in range(r):
+            if not mask >> i & 1:
+                term = term * (-raw[orders[i]])
+        total = total + term
+    return total
+
+
+def _central_moment_series(r, xi, raw):
+    """Taylor series of ``q_r`` in ``xi``; the 1/n! factors tame the factorial raw moments."""
+    series = 0.0
+    for m in range(_MOMENT_SERIES_TERMS + 1):
+        coef = 0.0
+        for orders in _partitions(m + r, r):  # orders_i = j_i + 1 >= 1, sum_i = m + r
+            denom = 1
+            for n in orders:
+                denom *= factorial(n)
+            coef = coef + _ordering_count(orders) * _joint_central_moment(orders, raw) / denom
+        series = series + coef * xi**m
+    return series
+
+
+def _central_moment_exact(r, xi, kappa):
+    """Exact ``q_r`` from the Beta moments ``E[Y ** i] = M(i xi)``; accurate away from xi = 0."""
+    sx = _safe_xi(xi)
+    mean_y = _pow_moment(1, sx, kappa)
+    central = sum(
+        comb(r, i) * (-1.0) ** (r - i) * _pow_moment(i, sx, kappa) * mean_y ** (r - i)
+        for i in range(r + 1)
+    )
+    return central / sx**r
+
+
+def _scaled_central_moment(r, xi, kappa, raw):
+    """``q_r = E[((W ** (-xi) - 1)/xi - mean) ** r]``: series near xi = 0, exact otherwise."""
+    return pt.switch(
+        pt.lt(pt.abs(xi), _MOMENT_SERIES_CUTOFF),
+        _central_moment_series(r, xi, raw),
+        _central_moment_exact(r, xi, kappa),
+    )
+
+
 def _central_moments(sigma, xi, kappa):
-    """Central moments ``E[(X - mu) ** r]`` for r = 1..4 (about mu, not the mean)."""
-    c = sigma / xi
-    m1, m2, m3, m4 = (_pow_moment(j, xi, kappa) for j in (1, 2, 3, 4))
-    p1 = c * (m1 - 1)
-    p2 = c**2 * (m2 - 2 * m1 + 1)
-    p3 = c**3 * (m3 - 3 * m2 + 3 * m1 - 1)
-    p4 = c**4 * (m4 - 4 * m3 + 6 * m2 - 4 * m1 + 1)
-    return p1, p2, p3, p4
+    """Central moments ``E[(X - mean) ** r]`` for r = 2, 3, 4."""
+    raw = _neglogw_raw_moments(kappa)
+    return tuple(sigma**r * _scaled_central_moment(r, xi, kappa, raw) for r in (2, 3, 4))
 
 
 def mean(mu, sigma, xi, kappa):
+    raw = _neglogw_raw_moments(kappa)
+    # Raw first scaled moment q1 = (M(xi) - 1)/xi = sum_m mu_{1+m}/(1+m)! xi^m near xi = 0.
+    series = sum(raw[1 + m] / factorial(1 + m) * xi**m for m in range(_MOMENT_SERIES_TERMS + 1))
     sx = _safe_xi(xi)
-    general = mu + sigma / sx * (_pow_moment(1, sx, kappa) - 1)
-    limit = mu + sigma * (pt.psi(kappa + 1) + pt.euler_gamma)  # xi -> 0
-    value = pt.switch(pt.eq(xi, 0.0), limit, general)
-    return pt.switch(pt.lt(xi, 1), value, np.inf)
+    q1 = pt.switch(
+        pt.lt(pt.abs(xi), _MOMENT_SERIES_CUTOFF), series, (_pow_moment(1, sx, kappa) - 1) / sx
+    )
+    return pt.switch(pt.lt(xi, 1), mu + sigma * q1, np.inf)
 
 
 def median(mu, sigma, xi, kappa):
@@ -236,11 +346,8 @@ def mode(mu, sigma, xi, kappa):
 
 
 def var(mu, sigma, xi, kappa):
-    sx = _safe_xi(xi)
-    p1, p2, _, _ = _central_moments(sigma, sx, kappa)
-    limit = sigma**2 * (pt.polygamma(1, 1.0) - pt.polygamma(1, kappa + 1))  # xi -> 0
-    value = pt.switch(pt.eq(xi, 0.0), limit, p2 - p1**2)
-    return pt.switch(pt.lt(xi, 0.5), value, np.inf)
+    variance, _, _ = _central_moments(sigma, xi, kappa)
+    return pt.switch(pt.lt(xi, 0.5), variance, np.inf)
 
 
 def std(mu, sigma, xi, kappa):
@@ -248,25 +355,14 @@ def std(mu, sigma, xi, kappa):
 
 
 def skewness(mu, sigma, xi, kappa):
-    sx = _safe_xi(xi)
-    p1, p2, p3, _ = _central_moments(sigma, sx, kappa)
-    general = (p3 - 3 * p1 * p2 + 2 * p1**3) / (p2 - p1**2) ** 1.5
-    tg = pt.polygamma(1, 1.0) - pt.polygamma(1, kappa + 1)
-    limit = (pt.polygamma(2, kappa + 1) - pt.polygamma(2, 1.0)) / tg**1.5  # xi -> 0
-    value = pt.switch(pt.eq(xi, 0.0), limit, general)
-    return pt.switch(pt.lt(xi, 1.0 / 3.0), value, np.nan)
+    variance, central3, _ = _central_moments(sigma, xi, kappa)
+    return pt.switch(pt.lt(xi, 1.0 / 3.0), central3 / variance**1.5, np.nan)
 
 
 def kurtosis(mu, sigma, xi, kappa):
     # Excess kurtosis.
-    sx = _safe_xi(xi)
-    p1, p2, p3, p4 = _central_moments(sigma, sx, kappa)
-    variance = p2 - p1**2
-    general = (p4 - 4 * p1 * p3 + 6 * p1**2 * p2 - 3 * p1**4) / variance**2 - 3
-    tg = pt.polygamma(1, 1.0) - pt.polygamma(1, kappa + 1)
-    limit = (pt.polygamma(3, 1.0) - pt.polygamma(3, kappa + 1)) / tg**2  # xi -> 0
-    value = pt.switch(pt.eq(xi, 0.0), limit, general)
-    return pt.switch(pt.lt(xi, 0.25), value, np.nan)
+    variance, _, central4 = _central_moments(sigma, xi, kappa)
+    return pt.switch(pt.lt(xi, 0.25), central4 / variance**2 - 3, np.nan)
 
 
 def entropy(mu, sigma, xi, kappa):

--- a/pytensor_distributions/extgenpareto.py
+++ b/pytensor_distributions/extgenpareto.py
@@ -5,6 +5,7 @@ import pytensor.tensor as pt
 from pytensor.tensor.special import betaln
 
 from pytensor_distributions.genpareto import (
+    _const_like,
     _gpd_log_H,
     _gpd_log_h,
     _gpd_log_S,
@@ -189,11 +190,17 @@ def _safe_xi(xi):
     ``nan``. The placeholder ``0.1`` lies in ``(0, 1/4)``, keeping every ``B(1 - j xi,
     kappa)`` (``j <= 4``) and ``B(n kappa, 1 - xi)`` finite.
     """
-    return pt.switch(pt.eq(xi, 0.0), 0.1, xi)
+    return pt.switch(pt.eq(xi, 0.0), _const_like(0.1, xi), xi)
 
 
 _MOMENT_SERIES_TERMS = 8  # Taylor order m = 0..8 in xi.
-_MOMENT_SERIES_CUTOFF = 1.8e-2  # |xi| below which the series beats the cancelling exact form.
+# |xi| below which the series beats the cancelling exact Beta form: where the series
+# truncation error (~ |xi| ** (TERMS + 1)) reaches float64 eps, i.e. eps ** (1 / (TERMS + 1)).
+# Float64-tuned on purpose -- the series' own joint central moments only reach float64
+# accuracy, so a float32 caller gains nothing from widening it (and the exact form is the
+# accurate branch for moderate |xi| there).
+_MOMENT_SERIES_CUTOFF = 1.8e-2
+
 
 # polygamma(d, 1) = (-1) ** (d + 1) * d! * zeta(d + 1), for d = 0..11. Baked as literals
 # because pytensor#2244 makes ``pt.polygamma(d, 1.0)`` (a constant argument) ~1e-9 inaccurate;
@@ -225,7 +232,7 @@ def _neglogw_raw_moments(kappa):
     for k in range(1, n_max + 1):
         d = k - 1
         poly_kappa = pt.psi(kappa + 1) if d == 0 else pt.polygamma(d, kappa + 1)
-        cumulants.append((-1.0) ** d * (poly_kappa - _POLYGAMMA_AT_ONE[d]))
+        cumulants.append((-1.0) ** d * (poly_kappa - _const_like(_POLYGAMMA_AT_ONE[d], kappa)))
     raw = [pt.ones_like(kappa)]
     for n in range(1, n_max + 1):
         raw.append(sum(comb(n - 1, i) * cumulants[n - 1 - i] * raw[i] for i in range(n)))
@@ -275,7 +282,10 @@ def _central_moment_series(r, xi, raw):
             denom = 1
             for n in orders:
                 denom *= factorial(n)
-            coef = coef + _ordering_count(orders) * _joint_central_moment(orders, raw) / denom
+            # denom matches raw's dtype: a bare factorial >= 2**15 would autocast a
+            # float32 result to float64. It is exact in float32 (< 2**24 here).
+            jcm = _joint_central_moment(orders, raw)
+            coef = coef + _ordering_count(orders) * jcm / _const_like(denom, raw[0])
         series = series + coef * xi**m
     return series
 
@@ -309,7 +319,10 @@ def _central_moments(sigma, xi, kappa):
 def mean(mu, sigma, xi, kappa):
     raw = _neglogw_raw_moments(kappa)
     # Raw first scaled moment q1 = (M(xi) - 1)/xi = sum_m mu_{1+m}/(1+m)! xi^m near xi = 0.
-    series = sum(raw[1 + m] / factorial(1 + m) * xi**m for m in range(_MOMENT_SERIES_TERMS + 1))
+    series = sum(
+        raw[1 + m] / _const_like(factorial(1 + m), raw[1 + m]) * xi**m
+        for m in range(_MOMENT_SERIES_TERMS + 1)
+    )
     sx = _safe_xi(xi)
     q1 = pt.switch(
         pt.lt(pt.abs(xi), _MOMENT_SERIES_CUTOFF), series, (_pow_moment(1, sx, kappa) - 1) / sx
@@ -319,7 +332,8 @@ def mean(mu, sigma, xi, kappa):
 
 def median(mu, sigma, xi, kappa):
     # F = 1/2  ->  H = (1/2) ** (1/kappa); excess m = -log(1 - H).
-    excess = _ext_gpd_excess_from_log_prob(np.log(0.5), kappa)
+    log_half = _const_like(np.log(0.5), mu, sigma, xi, kappa)
+    excess = _ext_gpd_excess_from_log_prob(log_half, kappa)
     return _gpd_quantile_from_excess(excess, mu, sigma, xi)
 
 
@@ -356,23 +370,22 @@ def std(mu, sigma, xi, kappa):
 
 def skewness(mu, sigma, xi, kappa):
     variance, central3, _ = _central_moments(sigma, xi, kappa)
-    return pt.switch(pt.lt(xi, 1.0 / 3.0), central3 / variance**1.5, np.nan)
+    nan = _const_like(np.nan, mu, sigma, xi, kappa)
+    return pt.switch(pt.lt(xi, 1.0 / 3.0), central3 / variance**1.5, nan)
 
 
 def kurtosis(mu, sigma, xi, kappa):
     # Excess kurtosis.
     variance, _, central4 = _central_moments(sigma, xi, kappa)
-    return pt.switch(pt.lt(xi, 0.25), central4 / variance**2 - 3, np.nan)
+    nan = _const_like(np.nan, mu, sigma, xi, kappa)
+    return pt.switch(pt.lt(xi, 0.25), central4 / variance**2 - 3, nan)
 
 
 def entropy(mu, sigma, xi, kappa):
     # -E[log g(X)] in closed form; reduces to the GPD's log(sigma) + xi + 1 at kappa = 1.
+    euler_gamma = _const_like(np.euler_gamma, mu, sigma, xi, kappa)
     return (
-        pt.log(sigma)
-        - pt.log(kappa)
-        + 1
-        - 1 / kappa
-        + (1 + xi) * (pt.psi(kappa + 1) + pt.euler_gamma)
+        pt.log(sigma) - pt.log(kappa) + 1 - 1 / kappa + (1 + xi) * (pt.psi(kappa + 1) + euler_gamma)
     )
 
 

--- a/pytensor_distributions/extgenpareto.py
+++ b/pytensor_distributions/extgenpareto.py
@@ -166,12 +166,26 @@ def rvs(mu, sigma, xi, kappa, size=None, random_state=None):
 # Summary statistics. With the substitution x = mu + (sigma/xi)(W ** (-xi) - 1),
 # W ~ Beta(1, kappa), the power moments reduce to Beta functions:
 #   E[W ** (-j xi)] = kappa * B(1 - j xi, kappa),
-# finite (like the plain GPD) only for j xi < 1, so each moment is guarded.
+# finite (like the plain GPD) only for j xi < 1, so each moment is guarded. The
+# exponential-tail limit xi -> 0 is a 0/0 in those Beta forms, so each statistic switches
+# to its closed-form digamma/polygamma limit there; ``_safe_xi`` keeps the discarded
+# branch finite so its gradient is not poisoned.
 
 
 def _pow_moment(j, xi, kappa):
     """``E[W ** (-j xi)] = kappa * B(1 - j xi, kappa)`` for ``W ~ Beta(1, kappa)``."""
     return pt.exp(pt.log(kappa) + betaln(1 - j * xi, kappa))
+
+
+def _safe_xi(xi):
+    """Nonzero stand-in for ``xi`` used only in the discarded ``xi != 0`` moment branch.
+
+    The Beta-function forms divide by ``xi``; at ``xi = 0`` that branch is not selected,
+    but ``pt.switch`` still differentiates it, so a raw ``0/0`` would make the gradient
+    ``nan``. The placeholder ``0.1`` lies in ``(0, 1/4)``, keeping every ``B(1 - j xi,
+    kappa)`` (``j <= 4``) and ``B(n kappa, 1 - xi)`` finite.
+    """
+    return pt.switch(pt.eq(xi, 0.0), 0.1, xi)
 
 
 def _central_moments(sigma, xi, kappa):
@@ -186,7 +200,11 @@ def _central_moments(sigma, xi, kappa):
 
 
 def mean(mu, sigma, xi, kappa):
-    return pt.switch(pt.lt(xi, 1), mu + sigma / xi * (_pow_moment(1, xi, kappa) - 1), np.inf)
+    sx = _safe_xi(xi)
+    general = mu + sigma / sx * (_pow_moment(1, sx, kappa) - 1)
+    limit = mu + sigma * (pt.psi(kappa + 1) + pt.euler_gamma)  # xi -> 0
+    value = pt.switch(pt.eq(xi, 0.0), limit, general)
+    return pt.switch(pt.lt(xi, 1), value, np.inf)
 
 
 def median(mu, sigma, xi, kappa):
@@ -196,15 +214,33 @@ def median(mu, sigma, xi, kappa):
 
 
 def mode(mu, sigma, xi, kappa):
-    # No closed form for kappa != 1; grid-search the log-density. For kappa <= 1 the
-    # density peaks at the lower endpoint mu, for kappa > 1 it is interior.
-    upper = ppf(np.asarray(1.0 - 1e-3), mu, sigma, xi, kappa)
-    return continuous_mode(mu, upper, logpdf, mu, sigma, xi, kappa, n_points=1000)
+    # No closed form for kappa != 1, so the interior case is a grid search:
+    #   xi < -1:                 density diverges at the finite upper endpoint (h blows up);
+    #   xi >= -1 and kappa <= 1: density peaks at the lower endpoint mu (H ** (kappa - 1)
+    #                            blows up for kappa < 1; the kappa = 1 GPD decreases from mu);
+    #   xi >= -1 and kappa > 1:  interior mode.
+    # This matches GenPareto.mode at kappa = 1.
+    upper = _gpd_upper_bound(mu, sigma, xi)
+    interior = continuous_mode(
+        mu,
+        ppf(np.asarray(1.0 - 1e-3), mu, sigma, xi, kappa),
+        logpdf,
+        mu,
+        sigma,
+        xi,
+        kappa,
+        n_points=1000,
+    )
+    at_mu = pt.broadcast_arrays(mu, sigma, xi, kappa)[0]
+    return pt.switch(pt.lt(xi, -1), upper, pt.switch(pt.le(kappa, 1.0), at_mu, interior))
 
 
 def var(mu, sigma, xi, kappa):
-    p1, p2, _, _ = _central_moments(sigma, xi, kappa)
-    return pt.switch(pt.lt(xi, 0.5), p2 - p1**2, np.inf)
+    sx = _safe_xi(xi)
+    p1, p2, _, _ = _central_moments(sigma, sx, kappa)
+    limit = sigma**2 * (pt.polygamma(1, 1.0) - pt.polygamma(1, kappa + 1))  # xi -> 0
+    value = pt.switch(pt.eq(xi, 0.0), limit, p2 - p1**2)
+    return pt.switch(pt.lt(xi, 0.5), value, np.inf)
 
 
 def std(mu, sigma, xi, kappa):
@@ -212,18 +248,25 @@ def std(mu, sigma, xi, kappa):
 
 
 def skewness(mu, sigma, xi, kappa):
-    p1, p2, p3, _ = _central_moments(sigma, xi, kappa)
-    variance = p2 - p1**2
-    central3 = p3 - 3 * p1 * p2 + 2 * p1**3
-    return pt.switch(pt.lt(xi, 1.0 / 3.0), central3 / variance**1.5, np.nan)
+    sx = _safe_xi(xi)
+    p1, p2, p3, _ = _central_moments(sigma, sx, kappa)
+    general = (p3 - 3 * p1 * p2 + 2 * p1**3) / (p2 - p1**2) ** 1.5
+    tg = pt.polygamma(1, 1.0) - pt.polygamma(1, kappa + 1)
+    limit = (pt.polygamma(2, kappa + 1) - pt.polygamma(2, 1.0)) / tg**1.5  # xi -> 0
+    value = pt.switch(pt.eq(xi, 0.0), limit, general)
+    return pt.switch(pt.lt(xi, 1.0 / 3.0), value, np.nan)
 
 
 def kurtosis(mu, sigma, xi, kappa):
     # Excess kurtosis.
-    p1, p2, p3, p4 = _central_moments(sigma, xi, kappa)
+    sx = _safe_xi(xi)
+    p1, p2, p3, p4 = _central_moments(sigma, sx, kappa)
     variance = p2 - p1**2
-    central4 = p4 - 4 * p1 * p3 + 6 * p1**2 * p2 - 3 * p1**4
-    return pt.switch(pt.lt(xi, 0.25), central4 / variance**2 - 3, np.nan)
+    general = (p4 - 4 * p1 * p3 + 6 * p1**2 * p2 - 3 * p1**4) / variance**2 - 3
+    tg = pt.polygamma(1, 1.0) - pt.polygamma(1, kappa + 1)
+    limit = (pt.polygamma(3, 1.0) - pt.polygamma(3, kappa + 1)) / tg**2  # xi -> 0
+    value = pt.switch(pt.eq(xi, 0.0), limit, general)
+    return pt.switch(pt.lt(xi, 0.25), value, np.nan)
 
 
 def entropy(mu, sigma, xi, kappa):
@@ -239,7 +282,8 @@ def entropy(mu, sigma, xi, kappa):
 
 # L-moments. With lambda_{r+1} = (sigma kappa / xi) * sum_k p*_{r,k} B(kappa (k+1), 1 - xi)
 # (p* the shifted Legendre coefficients), these reduce to the GPD L-moments at kappa = 1
-# and are finite for xi < 1.
+# and are finite for xi < 1. Like the ordinary moments they are a 0/0 at xi = 0 and switch
+# to a digamma limit there.
 
 
 def _lbeta(n, xi, kappa):
@@ -252,17 +296,34 @@ def lmoment1(mu, sigma, xi, kappa):
 
 
 def lmoment2(mu, sigma, xi, kappa):
-    l1, l2 = _lbeta(1, xi, kappa), _lbeta(2, xi, kappa)
-    return pt.switch(pt.lt(xi, 1), sigma * kappa / xi * (2 * l2 - l1), np.inf)
+    sx = _safe_xi(xi)
+    l1, l2 = _lbeta(1, sx, kappa), _lbeta(2, sx, kappa)
+    general = sigma * kappa / sx * (2 * l2 - l1)
+    limit = sigma * (pt.psi(2 * kappa + 1) - pt.psi(kappa + 1))  # xi -> 0
+    value = pt.switch(pt.eq(xi, 0.0), limit, general)
+    return pt.switch(pt.lt(xi, 1), value, np.inf)
 
 
 def lmoment3(mu, sigma, xi, kappa):
-    l1, l2, l3 = (_lbeta(n, xi, kappa) for n in (1, 2, 3))
-    tau3 = (6 * l3 - 6 * l2 + l1) / (2 * l2 - l1)
-    return pt.switch(pt.lt(xi, 1), tau3, np.inf)
+    sx = _safe_xi(xi)
+    l1, l2, l3 = (_lbeta(n, sx, kappa) for n in (1, 2, 3))
+    general = (6 * l3 - 6 * l2 + l1) / (2 * l2 - l1)
+    denom = pt.psi(2 * kappa + 1) - pt.psi(kappa + 1)
+    limit = (2 * pt.psi(3 * kappa + 1) - 3 * pt.psi(2 * kappa + 1) + pt.psi(kappa + 1)) / denom
+    value = pt.switch(pt.eq(xi, 0.0), limit, general)
+    return pt.switch(pt.lt(xi, 1), value, np.inf)
 
 
 def lmoment4(mu, sigma, xi, kappa):
-    l1, l2, l3, l4 = (_lbeta(n, xi, kappa) for n in (1, 2, 3, 4))
-    tau4 = (20 * l4 - 30 * l3 + 12 * l2 - l1) / (2 * l2 - l1)
-    return pt.switch(pt.lt(xi, 1), tau4, np.inf)
+    sx = _safe_xi(xi)
+    l1, l2, l3, l4 = (_lbeta(n, sx, kappa) for n in (1, 2, 3, 4))
+    general = (20 * l4 - 30 * l3 + 12 * l2 - l1) / (2 * l2 - l1)
+    denom = pt.psi(2 * kappa + 1) - pt.psi(kappa + 1)
+    limit = (
+        5 * pt.psi(4 * kappa + 1)
+        - 10 * pt.psi(3 * kappa + 1)
+        + 6 * pt.psi(2 * kappa + 1)
+        - pt.psi(kappa + 1)
+    ) / denom
+    value = pt.switch(pt.eq(xi, 0.0), limit, general)
+    return pt.switch(pt.lt(xi, 1), value, np.inf)

--- a/pytensor_distributions/extgenpareto.py
+++ b/pytensor_distributions/extgenpareto.py
@@ -16,6 +16,7 @@
 
 import numpy as np
 import pytensor.tensor as pt
+from pytensor.tensor.special import betaln
 
 from pytensor_distributions.genpareto import (
     _gpd_log_H,
@@ -26,7 +27,7 @@ from pytensor_distributions.genpareto import (
     _in_gpd_support,
     _log1p_div,
 )
-from pytensor_distributions.helper import ppf_bounds_cont
+from pytensor_distributions.helper import continuous_mode, ppf_bounds_cont
 
 # Extended Generalized Pareto core. Naveau et al. (2016) extended GPD with
 # carrier G(v) = v ** kappa: the CDF is F = H ** kappa with H the GPD CDF, so
@@ -161,3 +162,108 @@ def rvs(mu, sigma, xi, kappa, size=None, random_state=None):
     u = pt.random.uniform(size=size, rng=random_state, return_next_rng=True)[1]
     excess = _ext_gpd_excess_from_log_prob(pt.log(u), kappa)
     return _gpd_quantile_from_excess(excess, mu, sigma, xi)
+
+
+# Summary statistics. With the substitution x = mu + (sigma/xi)(W ** (-xi) - 1),
+# W ~ Beta(1, kappa), the power moments reduce to Beta functions:
+#   E[W ** (-j xi)] = kappa * B(1 - j xi, kappa),
+# finite (like the plain GPD) only for j xi < 1, so each moment is guarded.
+
+
+def _pow_moment(j, xi, kappa):
+    """``E[W ** (-j xi)] = kappa * B(1 - j xi, kappa)`` for ``W ~ Beta(1, kappa)``."""
+    return pt.exp(pt.log(kappa) + betaln(1 - j * xi, kappa))
+
+
+def _central_moments(sigma, xi, kappa):
+    """Central moments ``E[(X - mu) ** r]`` for r = 1..4 (about mu, not the mean)."""
+    c = sigma / xi
+    m1, m2, m3, m4 = (_pow_moment(j, xi, kappa) for j in (1, 2, 3, 4))
+    p1 = c * (m1 - 1)
+    p2 = c**2 * (m2 - 2 * m1 + 1)
+    p3 = c**3 * (m3 - 3 * m2 + 3 * m1 - 1)
+    p4 = c**4 * (m4 - 4 * m3 + 6 * m2 - 4 * m1 + 1)
+    return p1, p2, p3, p4
+
+
+def mean(mu, sigma, xi, kappa):
+    return pt.switch(pt.lt(xi, 1), mu + sigma / xi * (_pow_moment(1, xi, kappa) - 1), np.inf)
+
+
+def median(mu, sigma, xi, kappa):
+    # F = 1/2  ->  H = (1/2) ** (1/kappa); excess m = -log(1 - H).
+    excess = _ext_gpd_excess_from_log_prob(np.log(0.5), kappa)
+    return _gpd_quantile_from_excess(excess, mu, sigma, xi)
+
+
+def mode(mu, sigma, xi, kappa):
+    # No closed form for kappa != 1; grid-search the log-density. For kappa <= 1 the
+    # density peaks at the lower endpoint mu, for kappa > 1 it is interior.
+    upper = ppf(np.asarray(1.0 - 1e-3), mu, sigma, xi, kappa)
+    return continuous_mode(mu, upper, logpdf, mu, sigma, xi, kappa, n_points=1000)
+
+
+def var(mu, sigma, xi, kappa):
+    p1, p2, _, _ = _central_moments(sigma, xi, kappa)
+    return pt.switch(pt.lt(xi, 0.5), p2 - p1**2, np.inf)
+
+
+def std(mu, sigma, xi, kappa):
+    return pt.sqrt(var(mu, sigma, xi, kappa))
+
+
+def skewness(mu, sigma, xi, kappa):
+    p1, p2, p3, _ = _central_moments(sigma, xi, kappa)
+    variance = p2 - p1**2
+    central3 = p3 - 3 * p1 * p2 + 2 * p1**3
+    return pt.switch(pt.lt(xi, 1.0 / 3.0), central3 / variance**1.5, np.nan)
+
+
+def kurtosis(mu, sigma, xi, kappa):
+    # Excess kurtosis.
+    p1, p2, p3, p4 = _central_moments(sigma, xi, kappa)
+    variance = p2 - p1**2
+    central4 = p4 - 4 * p1 * p3 + 6 * p1**2 * p2 - 3 * p1**4
+    return pt.switch(pt.lt(xi, 0.25), central4 / variance**2 - 3, np.nan)
+
+
+def entropy(mu, sigma, xi, kappa):
+    # -E[log g(X)] in closed form; reduces to the GPD's log(sigma) + xi + 1 at kappa = 1.
+    return (
+        pt.log(sigma)
+        - pt.log(kappa)
+        + 1
+        - 1 / kappa
+        + (1 + xi) * (pt.psi(kappa + 1) + np.euler_gamma)
+    )
+
+
+# L-moments. With lambda_{r+1} = (sigma kappa / xi) * sum_k p*_{r,k} B(kappa (k+1), 1 - xi)
+# (p* the shifted Legendre coefficients), these reduce to the GPD L-moments at kappa = 1
+# and are finite for xi < 1.
+
+
+def _lbeta(n, xi, kappa):
+    """``B(n kappa, 1 - xi)``."""
+    return pt.exp(betaln(n * kappa, 1 - xi))
+
+
+def lmoment1(mu, sigma, xi, kappa):
+    return mean(mu, sigma, xi, kappa)
+
+
+def lmoment2(mu, sigma, xi, kappa):
+    l1, l2 = _lbeta(1, xi, kappa), _lbeta(2, xi, kappa)
+    return pt.switch(pt.lt(xi, 1), sigma * kappa / xi * (2 * l2 - l1), np.inf)
+
+
+def lmoment3(mu, sigma, xi, kappa):
+    l1, l2, l3 = (_lbeta(n, xi, kappa) for n in (1, 2, 3))
+    tau3 = (6 * l3 - 6 * l2 + l1) / (2 * l2 - l1)
+    return pt.switch(pt.lt(xi, 1), tau3, np.inf)
+
+
+def lmoment4(mu, sigma, xi, kappa):
+    l1, l2, l3, l4 = (_lbeta(n, xi, kappa) for n in (1, 2, 3, 4))
+    tau4 = (20 * l4 - 30 * l3 + 12 * l2 - l1) / (2 * l2 - l1)
+    return pt.switch(pt.lt(xi, 1), tau4, np.inf)

--- a/pytensor_distributions/extgenpareto.py
+++ b/pytensor_distributions/extgenpareto.py
@@ -90,9 +90,9 @@ def _ext_gpd_excess_from_log_prob(log_q, kappa):
     and its survival ``1 - H``, so ``m = -log(1 - H) = -log1mexp(log_q / kappa)``
     (``pt.log1mexp(a) = log(1 - exp(a))`` for ``a <= 0``). This form stays accurate when ``H``
     rounds to ``1``: for small ``kappa`` the survival ``1 - H`` is tiny, and forming it directly
-    would collapse the excess to ``0`` (and the quantile to ``mu``). Shared
-    by the quantile, the sampler, ``support_point`` and the default transform so
-    all four inverses agree. ``log_q`` must be ``<= 0`` (a log-probability).
+    would collapse the excess to ``0`` (and the quantile to ``mu``). Shared by
+    ``ppf``, ``isf`` and ``rvs`` so the inverses agree. ``log_q`` must be ``<= 0``
+    (a log-probability).
     """
     return -pt.log1mexp(log_q / kappa)
 
@@ -109,6 +109,7 @@ def _ext_gpd_excess_from_logit(value, kappa):
       tail (value >= cutoff, the extreme upper tail where F -> 1): a held in logs as log_a,
         m = -log_a where a < eps, else -log1mexp(-a).
     The unused branch's inputs are clamped (log_F via cutoff, a via log_max) so it stays finite.
+    Backs ``ppf_logit``.
     """
     finfo = np.finfo(value.dtype)
     log_max = float(np.log(finfo.max))  # a = exp(min(log_a, log_max)) stays finite
@@ -155,6 +156,20 @@ def isf(x, mu, sigma, xi, kappa):
     excess = _ext_gpd_excess_from_log_prob(pt.log1p(-x), kappa)
     quantile = _gpd_quantile_from_excess(excess, mu, sigma, xi)
     return ppf_bounds_cont(quantile, x, _gpd_upper_bound(mu, sigma, xi), mu)
+
+
+def ppf_logit(y, mu, sigma, xi, kappa):
+    """Quantile from the logit-CDF coordinate ``y = logit(F(x)) = logcdf - logsf``.
+
+    Equivalent to ``ppf(expit(y))`` but evaluated in log space (see
+    ``_ext_gpd_excess_from_logit``), so it stays accurate when ``F`` saturates to 0 or
+    1 deep in either tail. ``y`` is unconstrained (standard ``Logistic`` under the
+    model), so no bounds are applied. This is the inverse for a logit-CDF
+    (probability-integral) reparametrization, the stable unconstrained transform for
+    sampling the extended GPD as a latent variable.
+    """
+    excess = _ext_gpd_excess_from_logit(y, kappa)
+    return _gpd_quantile_from_excess(excess, mu, sigma, xi)
 
 
 def rvs(mu, sigma, xi, kappa, size=None, random_state=None):

--- a/pytensor_distributions/genpareto.py
+++ b/pytensor_distributions/genpareto.py
@@ -5,6 +5,19 @@ from pytensor.tensor.variable import TensorVariable
 from pytensor_distributions.helper import ppf_bounds_cont
 
 
+def _const_like(value, *refs):
+    """``value`` as a constant in the upcast dtype of ``refs``.
+
+    Numpy scalars and Python floats that are not exactly float32-representable
+    (``np.nan``, ``np.log(2)``, ...) are strong float64, so using them directly
+    upcasts an otherwise-float32 result to float64. Casting to the inputs' dtype
+    keeps each function's output dtype following its arguments while preserving
+    full float64 precision when the inputs are float64.
+    """
+    dtype = np.result_type(*(pt.as_tensor_variable(r).dtype for r in refs))
+    return np.asarray(value, dtype=dtype)
+
+
 def _series_cutoff(dtype) -> float:
     """``|u|`` below which the divided-difference helpers switch to their series.
 
@@ -182,7 +195,7 @@ def mean(mu, sigma, xi):
 
 def median(mu, sigma, xi):
     # Quantile at p = 1/2: excess m = -log(1 - 1/2) = log 2.
-    return _gpd_quantile_from_excess(np.log(2.0), mu, sigma, xi)
+    return _gpd_quantile_from_excess(_const_like(np.log(2.0), mu, sigma, xi), mu, sigma, xi)
 
 
 def mode(mu, sigma, xi):
@@ -202,13 +215,13 @@ def std(mu, sigma, xi):
 
 def skewness(mu, sigma, xi):
     value = 2 * (1 + xi) * pt.sqrt(1 - 2 * xi) / (1 - 3 * xi)
-    return pt.switch(pt.lt(xi, 1.0 / 3.0), value, np.nan)
+    return pt.switch(pt.lt(xi, 1.0 / 3.0), value, _const_like(np.nan, mu, sigma, xi))
 
 
 def kurtosis(mu, sigma, xi):
     # Excess kurtosis.
     value = 3 * (1 - 2 * xi) * (2 * xi**2 + xi + 3) / ((1 - 3 * xi) * (1 - 4 * xi)) - 3
-    return pt.switch(pt.lt(xi, 0.25), value, np.nan)
+    return pt.switch(pt.lt(xi, 0.25), value, _const_like(np.nan, mu, sigma, xi))
 
 
 def entropy(mu, sigma, xi):

--- a/pytensor_distributions/genpareto.py
+++ b/pytensor_distributions/genpareto.py
@@ -94,6 +94,12 @@ def logpdf(x, mu, sigma, xi):
     # in-support branch would evaluate log1p(inf)/inf -> nan there, so pin
     # z = +inf to -inf explicitly.
     logp = pt.switch(pt.eq(z, np.inf), -np.inf, logp)
+    # At the finite upper endpoint (xi < 0, 1 + xi z = 0) the density diverges for
+    # xi < -1, equals 1/sigma at xi = -1, and is 0 for -1 < xi < 0 (matches scipy's
+    # genpareto, and keeps pdf(mode) consistent where mode is that endpoint).
+    at_endpoint = pt.and_(pt.lt(xi, 0), pt.eq(1 + xi * z, 0))
+    endpoint = pt.switch(pt.lt(xi, -1), np.inf, pt.switch(pt.eq(xi, -1), -pt.log(sigma), -np.inf))
+    logp = pt.switch(at_endpoint, endpoint, logp)
     return logp
 
 

--- a/pytensor_distributions/genpareto.py
+++ b/pytensor_distributions/genpareto.py
@@ -163,6 +163,19 @@ def isf(x, mu, sigma, xi):
     return ppf_bounds_cont(quantile, x, _gpd_upper_bound(mu, sigma, xi), mu)
 
 
+def ppf_logit(y, mu, sigma, xi):
+    """Quantile from the logit-CDF coordinate ``y = logit(F(x)) = logcdf - logsf``.
+
+    Equivalent to ``ppf(expit(y))`` but evaluated without forming ``expit(y)``, so it
+    stays accurate when ``F`` saturates to 0 or 1 deep in either tail. ``y`` is
+    unconstrained (standard ``Logistic`` under the model), so no bounds are applied.
+    This is the inverse for a logit-CDF (probability-integral) reparametrization, the
+    stable unconstrained transform for sampling the GPD as a latent variable.
+    """
+    # excess m = -log S = -log(1 - expit(y)) = softplus(y).
+    return _gpd_quantile_from_excess(pt.softplus(y), mu, sigma, xi)
+
+
 def rvs(mu, sigma, xi, size=None, random_state=None):
     # Inverse-CDF on a survival draw: excess = -log(v) avoids the 1 - v cancellation.
     v = pt.random.uniform(size=size, rng=random_state, return_next_rng=True)[1]

--- a/pytensor_distributions/genpareto.py
+++ b/pytensor_distributions/genpareto.py
@@ -167,3 +167,67 @@ def rvs(mu, sigma, xi, size=None, random_state=None):
     # Inverse-CDF on a survival draw: excess = -log(v) avoids the 1 - v cancellation.
     v = pt.random.uniform(size=size, rng=random_state, return_next_rng=True)[1]
     return _gpd_quantile_from_excess(-pt.log(v), mu, sigma, xi)
+
+
+# Summary statistics. The r-th moment is finite only for xi < 1 / r, so each is
+# guarded and returns inf / nan past its threshold (matching scipy's genpareto).
+
+
+def mean(mu, sigma, xi):
+    return pt.switch(pt.lt(xi, 1), mu + sigma / (1 - xi), np.inf)
+
+
+def median(mu, sigma, xi):
+    # Quantile at p = 1/2: excess m = -log(1 - 1/2) = log 2.
+    return _gpd_quantile_from_excess(np.log(2.0), mu, sigma, xi)
+
+
+def mode(mu, sigma, xi):
+    # Density is monotone decreasing for xi >= -1 (mode at the lower endpoint mu);
+    # for xi < -1 it diverges at the finite upper endpoint.
+    mu_b, _, xi_b = pt.broadcast_arrays(mu, sigma, xi)
+    return pt.switch(pt.ge(xi_b, -1), mu_b, _gpd_upper_bound(mu, sigma, xi))
+
+
+def var(mu, sigma, xi):
+    return pt.switch(pt.lt(xi, 0.5), sigma**2 / ((1 - xi) ** 2 * (1 - 2 * xi)), np.inf)
+
+
+def std(mu, sigma, xi):
+    return pt.sqrt(var(mu, sigma, xi))
+
+
+def skewness(mu, sigma, xi):
+    value = 2 * (1 + xi) * pt.sqrt(1 - 2 * xi) / (1 - 3 * xi)
+    return pt.switch(pt.lt(xi, 1.0 / 3.0), value, np.nan)
+
+
+def kurtosis(mu, sigma, xi):
+    # Excess kurtosis.
+    value = 3 * (1 - 2 * xi) * (2 * xi**2 + xi + 3) / ((1 - 3 * xi) * (1 - 4 * xi)) - 3
+    return pt.switch(pt.lt(xi, 0.25), value, np.nan)
+
+
+def entropy(mu, sigma, xi):
+    return pt.log(sigma) + xi + 1
+
+
+# L-moments. With Hosking's shape k = -xi, the GPD has lambda_1 = mean,
+# lambda_2 = sigma / ((1 - xi)(2 - xi)), tau_3 = (1 + xi)/(3 - xi),
+# tau_4 = (1 + xi)(2 + xi)/((3 - xi)(4 - xi)); all finite for xi < 1.
+
+
+def lmoment1(mu, sigma, xi):
+    return mean(mu, sigma, xi)
+
+
+def lmoment2(mu, sigma, xi):
+    return pt.switch(pt.lt(xi, 1), sigma / ((1 - xi) * (2 - xi)), np.inf)
+
+
+def lmoment3(mu, sigma, xi):
+    return pt.switch(pt.lt(xi, 1), (1 + xi) / (3 - xi), np.inf)
+
+
+def lmoment4(mu, sigma, xi):
+    return pt.switch(pt.lt(xi, 1), (1 + xi) * (2 + xi) / ((3 - xi) * (4 - xi)), np.inf)

--- a/pytensor_distributions/genpareto.py
+++ b/pytensor_distributions/genpareto.py
@@ -1,0 +1,169 @@
+#   Copyright 2022 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Generalized Pareto distribution."""
+
+import numpy as np
+import pytensor.tensor as pt
+from pytensor.tensor.variable import TensorVariable
+
+from pytensor_distributions.helper import ppf_bounds_cont
+
+
+def _series_cutoff(dtype) -> float:
+    """``|u|`` below which the divided-difference helpers switch to their series.
+
+    The exact forms (``log(1 + u) / u``, ``(exp(u) - 1) / u``) are accurate in *value* for every
+    ``u != 0``, but autodiff builds their gradient as a difference that cancels with relative
+    error ``~ eps / |u|``. Balancing that against the series' ``~ u**4`` gradient-truncation
+    error puts the crossover at ``eps ** (1/5)``, so the cutoff tracks the dtype's ``eps`` (a
+    constant tuned for float64 is ~50x too small for float32). The crossover optimizes only
+    this single gradient (the first derivative), not the value (accurate either way) or higher
+    derivatives.
+    """
+    return float(np.finfo(dtype).eps) ** 0.2
+
+
+def _log1p_div(u: TensorVariable) -> TensorVariable:
+    """``log(1 + u) / u``, analytically continued across ``u = 0``.
+
+    ``safe_u`` keeps the naive branch away from ``u = 0`` where catastrophic cancellation occurs
+    for the gradient.
+    """
+    cutoff = _series_cutoff(u.dtype)
+    use_series = pt.lt(pt.abs(u), cutoff)
+    series = 1.0 - u / 2.0 + u**2 / 3.0 - u**3 / 4.0 + u**4 / 5.0
+    safe_u = pt.switch(use_series, np.asarray(1.0, dtype=u.dtype), u)
+    return pt.switch(use_series, series, pt.log1p(safe_u) / safe_u)
+
+
+def _expm1_div(u: TensorVariable) -> TensorVariable:
+    """``(exp(u) - 1) / u``, analytically continued across ``u = 0``.
+
+    Same series and ``safe_u`` construction as ``_log1p_div``.
+    """
+    cutoff = _series_cutoff(u.dtype)
+    use_series = pt.lt(pt.abs(u), cutoff)
+    series = 1.0 + u / 2.0 + u**2 / 6.0 + u**3 / 24.0 + u**4 / 120.0
+    safe_u = pt.switch(use_series, np.asarray(1.0, dtype=u.dtype), u)
+    return pt.switch(use_series, series, pt.expm1(safe_u) / safe_u)
+
+
+def _gpd_log_h(z, sigma, xi):
+    """GPD log-density, in-support expression (no support masking)."""
+    t = xi * z
+    return -pt.log(sigma) - pt.log1p(t) - z * _log1p_div(t)
+
+
+def _gpd_log_S(z, xi):
+    """GPD log survival ``log(1 - H) = -m``, in-support expression.
+
+    Computed directly from the survival exponent ``m = log1p(xi z) / xi`` rather
+    than as ``log1mexp(log H)``, so it stays accurate arbitrarily deep in the upper
+    tail (where ``log H -> 0`` and any ``H``-based route underflows).
+    """
+    return -(z * _log1p_div(xi * z))
+
+
+def _gpd_log_H(z, xi):
+    """GPD log-CDF, in-support expression (no support masking / no saturation)."""
+    return pt.log1mexp(_gpd_log_S(z, xi))
+
+
+def _gpd_quantile_from_excess(excess, mu, sigma, xi):
+    """Invert the GPD given ``excess = -log(survival) = m >= 0``.
+
+    ``z = expm1(xi m) / xi = m * expm1_div(xi m)`` -> ``value = mu + sigma z``.
+    Reused by the ``icdf`` method (``excess`` from a CDF probability) and by the
+    random Op (``excess`` from a uniform survival draw).
+    """
+    return mu + sigma * excess * _expm1_div(xi * excess)
+
+
+def _gpd_upper_bound(mu, sigma, xi):
+    """Right endpoint of the GPD support: ``mu - sigma / xi`` for xi < 0, else +inf."""
+    has_bounded_support = pt.lt(xi, 0)
+    div_xi = pt.switch(has_bounded_support, xi, 1.0)  # 1.0: arbitrary finite, discarded below
+    return pt.switch(has_bounded_support, mu - sigma / div_xi, np.inf)
+
+
+def _in_gpd_support(z, xi):
+    """GPD support mask: ``z >= 0`` and (for ``xi < 0``) ``s = 1 + xi z > 0``."""
+    return pt.and_(z >= 0, 1 + xi * z > 0)
+
+
+def logpdf(x, mu, sigma, xi):
+    z = (x - mu) / sigma
+    logp = pt.switch(_in_gpd_support(z, xi), _gpd_log_h(z, sigma, xi), -np.inf)
+    # The density vanishes at the +inf tail for every xi; for xi > 0 the
+    # in-support branch would evaluate log1p(inf)/inf -> nan there, so pin
+    # z = +inf to -inf explicitly.
+    logp = pt.switch(pt.eq(z, np.inf), -np.inf, logp)
+    return logp
+
+
+def logcdf(x, mu, sigma, xi):
+    z = (x - mu) / sigma
+    # Three regions: below mu -> 0 (log -inf); for xi < 0 past the finite upper
+    # endpoint mu - sigma/xi -> 1 (log 0); else log1mexp(-m).
+    above_upper = pt.and_(pt.lt(xi, 0), pt.le(1 + xi * z, 0))
+    logcdf = pt.switch(above_upper, 0.0, _gpd_log_H(z, xi))
+    logcdf = pt.switch(z >= 0, logcdf, -np.inf)
+    # CDF -> 1 (logcdf 0) at the +inf tail; for xi > 0 _gpd_log_H(inf) is nan.
+    logcdf = pt.switch(pt.eq(z, np.inf), 0.0, logcdf)
+    return logcdf
+
+
+def logsf(x, mu, sigma, xi):
+    z = (x - mu) / sigma
+    # m directly (log S = -m): accurate in the heavy tail, where the generic
+    # log1mexp(logcdf) survival fallback collapses (logcdf -> 0 there).
+    logsf = _gpd_log_S(z, xi)
+    # For xi < 0 past the finite upper endpoint, and at the +inf tail, S = 0.
+    above_upper = pt.and_(pt.lt(xi, 0), pt.le(1 + xi * z, 0))
+    logsf = pt.switch(pt.or_(above_upper, pt.eq(z, np.inf)), -np.inf, logsf)
+    # Below mu the survival is 1 (logsf 0).
+    logsf = pt.switch(z < 0, 0.0, logsf)
+    return logsf
+
+
+def ppf(q, mu, sigma, xi):
+    q = pt.as_tensor_variable(q)
+    x = _gpd_quantile_from_excess(-pt.log1p(-q), mu, sigma, xi)  # excess = -log(1 - q)
+    return ppf_bounds_cont(x, q, mu, _gpd_upper_bound(mu, sigma, xi))
+
+
+def cdf(x, mu, sigma, xi):
+    return pt.exp(logcdf(x, mu, sigma, xi))
+
+
+def pdf(x, mu, sigma, xi):
+    return pt.exp(logpdf(x, mu, sigma, xi))
+
+
+def sf(x, mu, sigma, xi):
+    return pt.exp(logsf(x, mu, sigma, xi))
+
+
+def isf(x, mu, sigma, xi):
+    x = pt.as_tensor_variable(x)
+    # m = -log(x) directly; ppf(1 - x) would lose a tiny x to the 1 - x rounding.
+    quantile = _gpd_quantile_from_excess(-pt.log(x), mu, sigma, xi)
+    return ppf_bounds_cont(quantile, x, _gpd_upper_bound(mu, sigma, xi), mu)
+
+
+def rvs(mu, sigma, xi, size=None, random_state=None):
+    # Inverse-CDF on a survival draw: excess = -log(v) avoids the 1 - v cancellation.
+    v = pt.random.uniform(size=size, rng=random_state, return_next_rng=True)[1]
+    return _gpd_quantile_from_excess(-pt.log(v), mu, sigma, xi)

--- a/pytensor_distributions/genpareto.py
+++ b/pytensor_distributions/genpareto.py
@@ -1,19 +1,3 @@
-#   Copyright 2022 The PyMC Developers
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
-
-"""Generalized Pareto distribution."""
-
 import numpy as np
 import pytensor.tensor as pt
 from pytensor.tensor.variable import TensorVariable

--- a/tests/test_extgenpareto.py
+++ b/tests/test_extgenpareto.py
@@ -20,6 +20,7 @@ import pytensor.tensor as pt
 import pytest
 import scipy.stats.distributions as sp
 from scipy import integrate, stats
+from scipy.special import expit
 
 from pytensor_distributions import extgenpareto as ExtGenPareto
 from pytensor_distributions import genpareto as GenPareto
@@ -122,6 +123,31 @@ def test_mode_is_the_global_maximum(mu, sigma, xi, kappa):
     grid = np.linspace(mu + 1e-6, upper, 4000)
     grid_max = max(pdf(x, mu, sigma, xi, kappa) for x in grid)
     assert pdf(m, mu, sigma, xi, kappa) >= 0.99 * grid_max
+
+
+@pytest.mark.parametrize(
+    "mu, sigma, xi, kappa", [(0.0, 1.0, 0.2, 1.5), (0.0, 1.0, -0.3, 0.7), (0.0, 1.0, 0.1, 3.0)]
+)
+def test_ppf_logit_matches_ppf_expit_and_round_trips(mu, sigma, xi, kappa):
+    params = [pt.constant(v, dtype="float64") for v in (mu, sigma, xi, kappa)]
+    y = np.array([-6.0, -2.0, 0.0, 2.0, 6.0])
+    np.testing.assert_allclose(
+        ExtGenPareto.ppf_logit(y, *params).eval(),
+        ExtGenPareto.ppf(expit(y), *params).eval(),
+        rtol=1e-8,
+    )
+    # forward (logit-CDF = logcdf - logsf) then ppf_logit recovers x
+    x = mu + sigma * np.array([0.1, 0.7, 2.0])
+    logit_F = (ExtGenPareto.logcdf(x, *params) - ExtGenPareto.logsf(x, *params)).eval()
+    np.testing.assert_allclose(ExtGenPareto.ppf_logit(logit_F, *params).eval(), x, rtol=1e-7)
+
+
+def test_ppf_logit_is_stable_in_the_upper_tail():
+    params = [pt.constant(v) for v in (0.0, 1.0, 0.2, 2.0)]  # unbounded
+    y = np.array([40.0, 80.0, 120.0])  # expit(y) rounds to 1.0, so ppf(expit(y)) would saturate
+    xt = ExtGenPareto.ppf_logit(y, *params).eval()
+    assert np.all(np.isfinite(xt))
+    assert np.all(np.diff(xt) > 0)
 
 
 def ref_ext_logpdf(value, mu, sigma, xi, kappa):

--- a/tests/test_extgenpareto.py
+++ b/tests/test_extgenpareto.py
@@ -455,6 +455,20 @@ def test_logsf_small_kappa_in_the_body_matches_reference(kappa):
     np.testing.assert_allclose(got, ref, rtol=1e-9)
 
 
+@pytest.mark.parametrize("dtype", ["float64", "float32"])
+def test_summary_stats_follow_input_dtype(dtype):
+    """mean/var/std/skewness/kurtosis/entropy/median/lmoments keep the input dtype.
+
+    (Value precision under float32 is a separate matter -- the high-order central
+    moments cancel and lose accuracy in a small-|xi| band; only the dtype is asserted.)
+    """
+    params = [pt.scalar(name, dtype=dtype) for name in ("mu", "sigma", "xi", "kappa")]
+    names = ["mean", "var", "std", "skewness", "kurtosis", "entropy"]
+    names += ["median", "lmoment1", "lmoment2", "lmoment3", "lmoment4"]
+    for name in names:
+        assert getattr(ExtGenPareto, name)(*params).dtype == dtype, name
+
+
 def test_boundary_logp_value_holds_but_gradient_tracks_the_margin():
     mu, sigma, xi, kappa = 0.4, 1.3, -0.3, 2.5
     eps = np.finfo(np.float64).eps

--- a/tests/test_extgenpareto.py
+++ b/tests/test_extgenpareto.py
@@ -1,0 +1,364 @@
+#   Copyright 2020 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from decimal import Decimal, getcontext
+
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+import scipy.stats.distributions as sp
+from scipy import stats
+
+from pytensor_distributions import extgenpareto as ExtGenPareto
+from pytensor_distributions import genpareto as GenPareto
+
+
+def ref_ext_logpdf(value, mu, sigma, xi, kappa):
+    z = (value - mu) / sigma
+    if z < 0 or (1 + xi * z) <= 0:
+        return -np.inf
+    log_H = sp.genpareto.logcdf(z, c=xi)
+    log_h = sp.genpareto.logpdf(z, c=xi) - np.log(sigma)
+    return np.log(kappa) + (kappa - 1) * log_H + log_h
+
+
+def ref_ext_logcdf(value, mu, sigma, xi, kappa):
+    z = (value - mu) / sigma
+    if z < 0:
+        return -np.inf
+    if xi < 0 and (1 + xi * z) <= 0:
+        return 0.0
+    return kappa * sp.genpareto.logcdf(z, c=xi)
+
+
+def ref_ext_logsf(value, mu, sigma, xi, kappa):
+    z = (value - mu) / sigma
+    if z < 0:
+        return 0.0
+    if xi < 0 and (1 + xi * z) <= 0:
+        return -np.inf
+    return np.log(-np.expm1(kappa * sp.genpareto.logcdf(z, c=xi)))
+
+
+def ref_ext_ppf(q, mu, sigma, xi, kappa):
+    return sp.genpareto.ppf(q ** (1 / kappa), c=xi, loc=mu, scale=sigma)
+
+
+def _gpd_ref_logp(value, mu, sigma, xi, kappa):
+    """100-digit ExtGPD logp from the exact margin ``s = 1 + xi*z``."""
+    getcontext().prec = 100
+    z = (Decimal(value) - mu) / sigma
+    log_s = (1 + xi * z).ln()
+    logp = -sigma.ln() - (1 + 1 / xi) * log_s
+    log_H = (1 - ((Decimal(-1) / xi) * log_s).exp()).ln()
+    return logp + kappa.ln() + (kappa - 1) * log_H
+
+
+def _gpd_ref_grad(value, params, which):
+    """High-precision central difference d logp / d ``which``."""
+    h = abs(params[which]) * Decimal("1e-22") or Decimal("1e-22")
+    hi = dict(params, **{which: params[which] + h})
+    lo = dict(params, **{which: params[which] - h})
+    return (_gpd_ref_logp(value, **hi) - _gpd_ref_logp(value, **lo)) / (2 * h)
+
+
+def _ext_gpd_excess_ref(y, kappa):
+    """High-precision GPD excess m = -log(1 - sigmoid(y) ** (1/kappa)) at xi = 0."""
+    getcontext().prec = 500
+    y, kappa = Decimal(y), Decimal(kappa)
+    log_sigmoid = -(1 + (-y).exp()).ln()
+    return float(-(1 - (log_sigmoid / kappa).exp()).ln())
+
+
+def test_functional_api_is_self_consistent():
+    x = np.array([0.3, 1.0, 3.0])
+    params = (0.0, 1.0, 0.2, 1.5)
+
+    np.testing.assert_allclose(
+        ExtGenPareto.cdf(x, *params).eval(), np.exp(ExtGenPareto.logcdf(x, *params).eval())
+    )
+    np.testing.assert_allclose(
+        ExtGenPareto.pdf(x, *params).eval(), np.exp(ExtGenPareto.logpdf(x, *params).eval())
+    )
+    np.testing.assert_allclose(
+        ExtGenPareto.sf(x, *params).eval(), np.exp(ExtGenPareto.logsf(x, *params).eval())
+    )
+    np.testing.assert_allclose(
+        ExtGenPareto.cdf(x, *params).eval() + ExtGenPareto.sf(x, *params).eval(),
+        1.0,
+        atol=1e-9,
+    )
+
+    q = np.array([0.1, 0.5, 0.9])
+    np.testing.assert_allclose(
+        ExtGenPareto.isf(q, *params).eval(), ExtGenPareto.ppf(1 - q, *params).eval()
+    )
+    assert np.all(np.isnan(ExtGenPareto.ppf(np.array([-0.1, 1.1]), *params).eval()))
+    np.testing.assert_allclose(float(ExtGenPareto.ppf(0.0, *params).eval()), 0.0)
+
+
+def test_isf_keeps_the_upper_tail():
+    # isf uses log1p(-x) (= log F) directly; ppf(1 - x) forms 1 - x first and loses the tiny
+    # survival x in the heavy upper tail. For xi = 0 the deep-tail isf is -log(x) + log(kappa);
+    # the direct route tracks it (rtol covers the O(x) asymptotic gap at x = 1e-8) while the naive
+    # ppf(1 - x) drifts off (~8e-4 at x = 1e-15).
+    x = np.array([1e-8, 1e-12, 1e-15])
+    for kappa in (0.5, 2.0, 10.0):
+        ref = -np.log(x) + np.log(kappa)
+        isf_val = ExtGenPareto.isf(x, 0.0, 1.0, 0.0, kappa).eval()
+        np.testing.assert_allclose(isf_val, ref, rtol=1e-9)
+        naive = ExtGenPareto.ppf(1 - x, 0.0, 1.0, 0.0, kappa).eval()
+        assert abs(isf_val[-1] - ref[-1]) < abs(naive[-1] - ref[-1])
+
+
+def test_rvs_shape_dtype_and_random_state():
+    params = (0.0, 1.0, 0.2, 1.5)
+    draws = ExtGenPareto.rvs(
+        *params, size=(4, 3), random_state=pytensor.shared(np.random.default_rng(0))
+    )
+    out = draws.eval()
+    assert out.shape == (4, 3) and out.dtype == np.float64
+    assert np.all(out >= 0.0)
+
+    same = ExtGenPareto.rvs(
+        *params, size=(4, 3), random_state=pytensor.shared(np.random.default_rng(0))
+    ).eval()
+    diff = ExtGenPareto.rvs(
+        *params, size=(4, 3), random_state=pytensor.shared(np.random.default_rng(9))
+    ).eval()
+    np.testing.assert_array_equal(out, same)
+    assert not np.array_equal(out, diff)
+
+
+@pytest.mark.parametrize(
+    "mu, sigma, xi, kappa",
+    [
+        (0.0, 1.0, -0.3, 0.5),
+        (0.0, 1.0, 0.0, 2.0),
+        (1.0, 2.0, 0.4, 3.0),
+    ],
+)
+def test_logpdf_logcdf_logsf_ppf_match_references(mu, sigma, xi, kappa):
+    upper = mu - sigma / xi if xi < 0 else 10.0
+    x = np.linspace(mu + 0.05, upper - 0.05 if xi < 0 else upper, 20)
+    q = np.array([0.1, 0.5, 0.9])
+
+    np.testing.assert_allclose(
+        ExtGenPareto.logpdf(x, mu, sigma, xi, kappa).eval(),
+        [ref_ext_logpdf(v, mu, sigma, xi, kappa) for v in x],
+        rtol=1e-8,
+        atol=1e-8,
+    )
+    np.testing.assert_allclose(
+        ExtGenPareto.logcdf(x, mu, sigma, xi, kappa).eval(),
+        [ref_ext_logcdf(v, mu, sigma, xi, kappa) for v in x],
+        rtol=1e-8,
+    )
+    np.testing.assert_allclose(
+        ExtGenPareto.logsf(x, mu, sigma, xi, kappa).eval(),
+        [ref_ext_logsf(v, mu, sigma, xi, kappa) for v in x],
+        rtol=1e-8,
+    )
+    np.testing.assert_allclose(
+        ExtGenPareto.ppf(q, mu, sigma, xi, kappa).eval(),
+        ref_ext_ppf(q, mu, sigma, xi, kappa),
+        rtol=1e-10,
+    )
+
+
+def test_logpdf_logcdf_at_infinity():
+    x = pt.constant(np.inf)
+    xi = pt.constant(np.array([-0.5, 0.0, 0.5]))
+    assert np.all(ExtGenPareto.logpdf(x, 0.0, 1.0, xi, 2.0).eval() == -np.inf)
+    assert np.all(ExtGenPareto.logcdf(x, 0.0, 1.0, xi, 2.0).eval() == 0.0)
+
+
+def test_ppf_endpoints():
+    xi = np.array([-0.5, 0.0, 0.5])
+    kappa = np.array([2.0, 0.5, 3.0])
+    with np.errstate(divide="ignore"):
+        expected_hi = np.where(xi < 0, 1.0 - 2.0 / xi, np.inf)
+    assert np.all(ExtGenPareto.ppf(0.0, 1.0, 2.0, xi, kappa).eval() == 1.0)
+    np.testing.assert_allclose(ExtGenPareto.ppf(1.0, 1.0, 2.0, xi, kappa).eval(), expected_hi)
+
+
+def test_ppf_outside_unit_interval_is_nan():
+    for q in (-0.1, 1.1):
+        assert np.isnan(ExtGenPareto.ppf(q, 0.0, 1.0, 0.2, 2.0).eval())
+
+
+def test_logsf_reduces_to_gpd_at_kappa_one():
+    value = np.linspace(0.05, 8.0, 40)
+    for xi in (-0.3, 0.0, 0.4):
+        ext = ExtGenPareto.logsf(value, 0.0, 1.5, xi, 1.0).eval()
+        gpd = GenPareto.logsf(value, 0.0, 1.5, xi).eval()
+        np.testing.assert_allclose(ext, gpd, rtol=1e-12, atol=1e-12)
+
+
+def test_kappa_one_equals_gpd():
+    value = np.linspace(0.0, 8.0, 60)
+    for xi in (-0.3, -1e-8, 0.0, 0.25, 0.8):
+        ext = ExtGenPareto.logpdf(value, 0.0, 1.5, xi, 1.0).eval()
+        gpd = GenPareto.logpdf(value, 0.0, 1.5, xi).eval()
+        np.testing.assert_allclose(ext, gpd, rtol=1e-12, atol=1e-12)
+
+
+def test_rvs_matches_distribution():
+    for xi, kappa in ((-0.2, 0.5), (0.0, 2.0), (0.3, 3.0)):
+        draws = ExtGenPareto.rvs(
+            0.0, 1.0, xi, kappa, size=20_000, random_state=pytensor.shared(np.random.default_rng(7))
+        ).eval()
+        u = ExtGenPareto.cdf(draws, 0.0, 1.0, xi, kappa).eval()
+        assert stats.kstest(u, "uniform").pvalue > 0.01
+
+
+@pytest.mark.parametrize("kappa", [0.5, 0.01])
+def test_small_kappa_ppf_uses_stable_excess(kappa):
+    median = ref_ext_ppf(0.5, 0.0, 1.0, 0.0, kappa)
+    assert median > 0.0
+
+    got = float(ExtGenPareto.ppf(0.5, 0.0, 1.0, 0.0, kappa).eval())
+    np.testing.assert_allclose(got, median, rtol=1e-6)
+
+
+def test_small_kappa_draws_do_not_collapse_to_mu():
+    draws = ExtGenPareto.rvs(
+        0.0, 1.0, 0.0, 0.01, size=20_000, random_state=pytensor.shared(np.random.default_rng(7))
+    ).eval()
+    assert (draws >= 0.0).all()
+    assert np.mean(draws == 0.0) < 0.01
+
+
+@pytest.mark.parametrize("dtype", ["float64", "float32"])
+def test_excess_from_logit_across_cutoff_for_huge_kappa(dtype):
+    y = pt.scalar("y", dtype=dtype)
+    kappa = pt.scalar("kappa", dtype=dtype)
+    m = ExtGenPareto._ext_gpd_excess_from_logit(y, kappa)
+    f = pytensor.function([y, kappa], [m, *pt.grad(m, [y, kappa])])
+    rtol = 1e-12 if dtype == "float64" else 1e-5
+    ys = [0.0, 200.0, 500.0, 680.0, 700.0, 730.0] if dtype == "float64" else [0.0, 50.0, 70.0, 85.0]
+    for yv in ys:
+        for kv in (1.0, 1e3, 1e8, 1e15):
+            m_val, dy, dk = f(np.asarray(yv, dtype), np.asarray(kv, dtype))
+            assert np.all(np.isfinite([m_val, dy, dk])), f"non-finite at y={yv}, kappa={kv}"
+            np.testing.assert_allclose(
+                float(m_val),
+                _ext_gpd_excess_ref(yv, kv),
+                rtol=rtol,
+                err_msg=f"excess wrong at y={yv}, kappa={kv}",
+            )
+
+
+def test_excess_from_logit_upper_tail_is_finite_under_float32():
+    y = pt.scalar("y", dtype="float32")
+    excess = ExtGenPareto._ext_gpd_excess_from_logit(y, np.float32(2.0))
+    assert excess.dtype == "float32"
+    fn = pytensor.function([y], excess)
+    for yi in (90.0, 200.0, 700.0, 5000.0):
+        m = float(fn(np.float32(yi)))
+        assert np.isfinite(m)
+        np.testing.assert_allclose(m, yi + np.log(2.0), rtol=1e-3)
+
+
+def test_excess_from_logit_resolves_subnormal_kappa_tail():
+    y = pt.dscalar("y")
+    excess = float(
+        pytensor.function([y], ExtGenPareto._ext_gpd_excess_from_logit(y, 4e-309))(710.0)
+    )
+    assert excess > 0.0
+    np.testing.assert_allclose(excess, 0.395390331, rtol=1e-4)
+
+
+def test_logsf_stable_in_far_tail():
+    for kappa in (0.5, 1.0, 2.5, 5.0):
+        x = np.array([100.0, 300.0, 1000.0])
+        got = ExtGenPareto.logsf(x, 0.0, 1.0, 0.0, kappa).eval()
+        assert np.all(np.isfinite(got))
+        np.testing.assert_allclose(got, np.log(kappa) - x, rtol=1e-9)
+
+
+@pytest.mark.parametrize("kappa", [10.0, 1e155, 1e300])
+def test_logsf_is_a_valid_log_probability_for_large_kappa(kappa):
+    x = np.array([40.0, 100.0, 1000.0])
+    kappa_t = pt.constant(np.asarray(kappa, dtype="float64"))
+    got = ExtGenPareto.logsf(x, 0.0, 1.0, 0.0, kappa_t).eval()
+    assert np.all(got <= 0.0)
+    small = np.log(kappa) - x < -30.0
+    np.testing.assert_allclose(got[small], (np.log(kappa) - x)[small], rtol=1e-9)
+
+
+@pytest.mark.parametrize("kappa", [1e-2, 1e-100])
+def test_logsf_small_kappa_in_the_body_matches_reference(kappa):
+    x = np.array([0.01, 0.1, 0.5, 2.0])
+    got = ExtGenPareto.logsf(x, 0.0, 1.0, 0.0, kappa).eval()
+    ref = np.log(-np.expm1(kappa * np.log1p(-np.exp(-x))))
+    np.testing.assert_allclose(got, ref, rtol=1e-9)
+
+
+def test_boundary_logp_value_holds_but_gradient_tracks_the_margin():
+    mu, sigma, xi, kappa = 0.4, 1.3, -0.3, 2.5
+    eps = np.finfo(np.float64).eps
+    margins = [1e-2, 1e-6, 1e-12]
+
+    v, sig, xs, ks = (pt.dscalar(n) for n in ("v", "sig", "xs", "ks"))
+    logp = ExtGenPareto.logpdf(v, mu, sig, xs, ks)
+    fn = pytensor.function(
+        [v, sig, xs, ks],
+        [logp, pt.grad(logp, sig), pt.grad(logp, xs), pt.grad(logp, ks)],
+    )
+
+    params = {
+        "mu": Decimal(mu),
+        "sigma": Decimal(sigma),
+        "xi": Decimal(xi),
+        "kappa": Decimal(kappa),
+    }
+    prev_logp = np.inf
+    for s_target in margins:
+        value = mu + sigma * ((s_target - 1) / xi)
+        logp_f, *grads_f = (float(o) for o in fn(value, sigma, xi, kappa))
+        logp_ref = _gpd_ref_logp(value, **params)
+
+        assert np.isfinite(logp_f), s_target
+        assert all(np.isfinite(g) for g in grads_f), s_target
+        assert logp_f < prev_logp, s_target
+        prev_logp = logp_f
+        assert abs((Decimal(logp_f) - logp_ref) / logp_ref) < 1e-4, s_target
+
+        grad_bound = 100 * eps / s_target
+        for name, g in zip(["sigma", "xi", "kappa"], grads_f):
+            g_ref = _gpd_ref_grad(value, params, name)
+            rel = abs((Decimal(g) - g_ref) / g_ref)
+            assert np.sign(g) == np.sign(float(g_ref)), (name, s_target)
+            if name == "kappa":
+                assert rel < 1e-10, (name, s_target, float(rel))
+            else:
+                assert rel < grad_bound, (name, s_target, float(rel))
+
+
+def test_logp_gradient_is_continuous_through_xi_zero():
+    xi = pt.dscalar("xi")
+    logp = ExtGenPareto.logpdf(pt.constant(2.3), 0.0, 1.0, xi, 2.0)
+    fn = pytensor.function([xi], [logp, pt.grad(logp, xi)], on_unused_input="ignore")
+
+    _, grad0 = fn(0.0)
+    assert np.isfinite(grad0)
+    _, grad_minus = fn(-1e-7)
+    _, grad_plus = fn(1e-7)
+    assert abs(grad_minus - grad0) < 1e-5
+    assert abs(grad_plus - grad0) < 1e-5
+    h = 1e-5
+    fd = (fn(h)[0] - fn(-h)[0]) / (2 * h)
+    assert abs(grad0 - fd) < 1e-5

--- a/tests/test_extgenpareto.py
+++ b/tests/test_extgenpareto.py
@@ -19,10 +19,109 @@ import pytensor
 import pytensor.tensor as pt
 import pytest
 import scipy.stats.distributions as sp
-from scipy import stats
+from scipy import integrate, stats
 
 from pytensor_distributions import extgenpareto as ExtGenPareto
 from pytensor_distributions import genpareto as GenPareto
+
+
+def _compile_scalar(fn, n):
+    """Compile ``fn(x, *params)`` for scalar inputs (used by the quad moment checks)."""
+    x = pt.dscalar("x")
+    ps = [pt.dscalar(f"p{i}") for i in range(n)]
+    return pytensor.function([x, *ps], fn(x, *ps), on_unused_input="ignore")
+
+
+def _stat(fn, *params):
+    return float(fn(*[pt.constant(v, dtype="float64") for v in params]).eval())
+
+
+_MOMENT_CASES = [
+    (0.0, 1.0, 0.1, 2.0),
+    (0.0, 1.0, 0.2, 0.5),
+    (1.0, 2.0, -0.2, 3.0),
+    (0.0, 1.0, -0.3, 0.7),
+]
+
+
+@pytest.mark.parametrize("mu, sigma, xi, kappa", _MOMENT_CASES)
+def test_moments_match_numerical_integration(mu, sigma, xi, kappa):
+    """mean/var/std/skewness/kurtosis/entropy/median against quadrature of the pdf."""
+    pdf = _compile_scalar(ExtGenPareto.pdf, 4)
+    logpdf = _compile_scalar(ExtGenPareto.logpdf, 4)
+    upper = mu - sigma / xi if xi < 0 else np.inf
+    raw = [
+        integrate.quad(
+            lambda x, r=r: (x - mu) ** r * pdf(x, mu, sigma, xi, kappa), mu, upper, limit=200
+        )[0]
+        for r in range(1, 5)
+    ]
+    m1, m2, m3, m4 = raw
+    var_q = m2 - m1**2
+    central3 = m3 - 3 * m1 * m2 + 2 * m1**3
+    central4 = m4 - 4 * m1 * m3 + 6 * m1**2 * m2 - 3 * m1**4
+    entropy_q = integrate.quad(
+        lambda x: -pdf(x, mu, sigma, xi, kappa) * logpdf(x, mu, sigma, xi, kappa),
+        mu,
+        upper,
+        limit=200,
+    )[0]
+    assert np.isclose(_stat(ExtGenPareto.mean, mu, sigma, xi, kappa), mu + m1, rtol=1e-5)
+    assert np.isclose(_stat(ExtGenPareto.var, mu, sigma, xi, kappa), var_q, rtol=1e-5)
+    assert np.isclose(_stat(ExtGenPareto.std, mu, sigma, xi, kappa), np.sqrt(var_q), rtol=1e-5)
+    assert np.isclose(
+        _stat(ExtGenPareto.skewness, mu, sigma, xi, kappa), central3 / var_q**1.5, rtol=1e-4
+    )
+    assert np.isclose(
+        _stat(ExtGenPareto.kurtosis, mu, sigma, xi, kappa), central4 / var_q**2 - 3, rtol=1e-4
+    )
+    assert np.isclose(_stat(ExtGenPareto.entropy, mu, sigma, xi, kappa), entropy_q, rtol=1e-5)
+    ppf_half = float(
+        ExtGenPareto.ppf(pt.constant(0.5), *[pt.constant(v) for v in (mu, sigma, xi, kappa)]).eval()
+    )
+    assert np.isclose(_stat(ExtGenPareto.median, mu, sigma, xi, kappa), ppf_half, rtol=1e-6)
+
+
+@pytest.mark.parametrize("mu, sigma, xi", [(0.0, 1.0, 0.1), (2.0, 0.5, -0.3), (0.0, 2.0, 0.2)])
+def test_lmoments_reduce_to_gpd_at_kappa_one(mu, sigma, xi):
+    """At kappa = 1 the ExtGPD L-moments collapse onto the plain GPD's."""
+    for ext, gpd in [
+        (ExtGenPareto.lmoment2, GenPareto.lmoment2),
+        (ExtGenPareto.lmoment3, GenPareto.lmoment3),
+        (ExtGenPareto.lmoment4, GenPareto.lmoment4),
+    ]:
+        assert np.isclose(_stat(ext, mu, sigma, xi, 1.0), _stat(gpd, mu, sigma, xi), rtol=1e-10)
+
+
+@pytest.mark.parametrize("mu, sigma, xi, kappa", [(0.0, 1.0, 0.1, 2.0), (0.0, 1.0, -0.3, 0.7)])
+def test_lmoments_match_sample(mu, sigma, xi, kappa):
+    """Closed-form L-moments against sample L-moments (scipy.stats.lmoment)."""
+    rng = pt.random.default_rng(42)
+    params = [pt.constant(v) for v in (mu, sigma, xi, kappa)]
+    data = ExtGenPareto.rvs(*params, size=80_000, random_state=rng).eval()
+    s_l2, s_tau3, s_tau4 = stats.lmoment(data, order=[2, 3, 4])
+    assert np.isclose(
+        _stat(ExtGenPareto.lmoment2, mu, sigma, xi, kappa), s_l2, rtol=5e-2, atol=5e-2
+    )
+    assert np.isclose(
+        _stat(ExtGenPareto.lmoment3, mu, sigma, xi, kappa), s_tau3, rtol=5e-2, atol=5e-2
+    )
+    assert np.isclose(
+        _stat(ExtGenPareto.lmoment4, mu, sigma, xi, kappa), s_tau4, rtol=5e-2, atol=5e-2
+    )
+
+
+@pytest.mark.parametrize(
+    "mu, sigma, xi, kappa", [(0.0, 1.0, 0.1, 3.0), (0.0, 1.0, -0.2, 2.5), (0.0, 1.0, 0.1, 0.6)]
+)
+def test_mode_is_the_global_maximum(mu, sigma, xi, kappa):
+    """The grid mode carries (within 1%) the largest density over a fine grid."""
+    pdf = _compile_scalar(ExtGenPareto.pdf, 4)
+    m = _stat(ExtGenPareto.mode, mu, sigma, xi, kappa)
+    upper = _stat(ExtGenPareto.ppf, 0.999, mu, sigma, xi, kappa)
+    grid = np.linspace(mu + 1e-6, upper, 4000)
+    grid_max = max(pdf(x, mu, sigma, xi, kappa) for x in grid)
+    assert pdf(m, mu, sigma, xi, kappa) >= 0.99 * grid_max
 
 
 def ref_ext_logpdf(value, mu, sigma, xi, kappa):

--- a/tests/test_extgenpareto.py
+++ b/tests/test_extgenpareto.py
@@ -1,16 +1,4 @@
-#   Copyright 2020 The PyMC Developers
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+"""Tests for the Extended Generalized Pareto distribution."""
 
 from decimal import Decimal, getcontext
 
@@ -398,10 +386,13 @@ def test_excess_from_logit_upper_tail_is_finite_under_float32():
 
 
 def test_excess_from_logit_resolves_subnormal_kappa_tail():
+    # kappa is passed symbolically rather than baked in: a constant subnormal kappa
+    # makes a graph rewrite fold ``x / kappa`` and overflow at compile time (the value
+    # is still correct, but it emits a spurious RuntimeWarning).
     y = pt.dscalar("y")
-    excess = float(
-        pytensor.function([y], ExtGenPareto._ext_gpd_excess_from_logit(y, 4e-309))(710.0)
-    )
+    kappa = pt.dscalar("kappa")
+    fn = pytensor.function([y, kappa], ExtGenPareto._ext_gpd_excess_from_logit(y, kappa))
+    excess = float(fn(710.0, 4e-309))
     assert excess > 0.0
     np.testing.assert_allclose(excess, 0.395390331, rtol=1e-4)
 

--- a/tests/test_extgenpareto.py
+++ b/tests/test_extgenpareto.py
@@ -30,6 +30,8 @@ _MOMENT_CASES = [
     (0.0, 1.0, 0.2, 0.5),
     (1.0, 2.0, -0.2, 3.0),
     (0.0, 1.0, -0.3, 0.7),
+    (0.0, 1.0, 0.0, 2.0),  # xi = 0: exponential-tail limit
+    (1.0, 2.0, 0.0, 0.5),
 ]
 
 
@@ -71,7 +73,9 @@ def test_moments_match_numerical_integration(mu, sigma, xi, kappa):
     assert np.isclose(_stat(ExtGenPareto.median, mu, sigma, xi, kappa), ppf_half, rtol=1e-6)
 
 
-@pytest.mark.parametrize("mu, sigma, xi", [(0.0, 1.0, 0.1), (2.0, 0.5, -0.3), (0.0, 2.0, 0.2)])
+@pytest.mark.parametrize(
+    "mu, sigma, xi", [(0.0, 1.0, 0.1), (2.0, 0.5, -0.3), (0.0, 2.0, 0.2), (0.0, 1.0, 0.0)]
+)
 def test_lmoments_reduce_to_gpd_at_kappa_one(mu, sigma, xi):
     """At kappa = 1 the ExtGPD L-moments collapse onto the plain GPD's."""
     for ext, gpd in [
@@ -82,7 +86,9 @@ def test_lmoments_reduce_to_gpd_at_kappa_one(mu, sigma, xi):
         assert np.isclose(_stat(ext, mu, sigma, xi, 1.0), _stat(gpd, mu, sigma, xi), rtol=1e-10)
 
 
-@pytest.mark.parametrize("mu, sigma, xi, kappa", [(0.0, 1.0, 0.1, 2.0), (0.0, 1.0, -0.3, 0.7)])
+@pytest.mark.parametrize(
+    "mu, sigma, xi, kappa", [(0.0, 1.0, 0.1, 2.0), (0.0, 1.0, -0.3, 0.7), (0.0, 1.0, 0.0, 2.0)]
+)
 def test_lmoments_match_sample(mu, sigma, xi, kappa):
     """Closed-form L-moments against sample L-moments (scipy.stats.lmoment)."""
     rng = pt.random.default_rng(42)
@@ -111,6 +117,32 @@ def test_mode_is_the_global_maximum(mu, sigma, xi, kappa):
     grid = np.linspace(mu + 1e-6, upper, 4000)
     grid_max = max(pdf(x, mu, sigma, xi, kappa) for x in grid)
     assert pdf(m, mu, sigma, xi, kappa) >= 0.99 * grid_max
+
+
+@pytest.mark.parametrize("xi", [-2.0, -1.5, -1.0, -0.5, 0.0, 0.3])
+def test_mode_matches_genpareto_at_kappa_one(xi):
+    """At kappa = 1 the ExtGPD mode collapses onto the GPD mode.
+
+    This includes xi < -1 (the diverging finite endpoint), which a plain interior grid
+    search would miss.
+    """
+    ext = _stat(ExtGenPareto.mode, 0.0, 1.0, xi, 1.0)
+    gpd = _stat(GenPareto.mode, 0.0, 1.0, xi)
+    assert np.isclose(ext, gpd, rtol=1e-9, atol=1e-9)
+
+
+@pytest.mark.parametrize("bad", ["sigma", "kappa"])
+def test_invalid_params_give_nonfinite_logpdf(bad):
+    """Invalid sigma/kappa give a non-finite logpdf, never a plausible density.
+
+    Parameter validation is the consuming wrapper's job (e.g. pymc's check_parameters).
+    """
+    mu, sigma, xi, kappa = 0.0, 1.0, 0.2, 1.5
+    if bad == "sigma":
+        sigma = -1.0
+    else:
+        kappa = -0.5
+    assert not np.isfinite(_stat(ExtGenPareto.logpdf, 0.5, mu, sigma, xi, kappa))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_genpareto.py
+++ b/tests/test_genpareto.py
@@ -1,16 +1,4 @@
-#   Copyright 2020 The PyMC Developers
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+"""Tests for the Generalized Pareto distribution."""
 
 from decimal import Decimal, getcontext
 

--- a/tests/test_genpareto.py
+++ b/tests/test_genpareto.py
@@ -19,9 +19,31 @@ import pytensor
 import pytensor.tensor as pt
 import pytest
 import scipy.stats.distributions as sp
+from scipy.special import expit
 
 from pytensor_distributions import genpareto as GenPareto
 from tests.helper_scipy import make_params, run_distribution_tests
+
+
+@pytest.mark.parametrize("mu, sigma, xi", [(0.0, 1.0, 0.2), (1.0, 2.0, 0.0), (0.0, 1.0, -0.3)])
+def test_ppf_logit_matches_ppf_expit_and_round_trips(mu, sigma, xi):
+    params = make_params(mu, sigma, xi, dtype="float64")
+    y = np.array([-6.0, -2.0, 0.0, 2.0, 6.0])
+    np.testing.assert_allclose(
+        GenPareto.ppf_logit(y, *params).eval(), GenPareto.ppf(expit(y), *params).eval(), rtol=1e-9
+    )
+    # forward (logit-CDF = logcdf - logsf) then ppf_logit recovers x
+    x = mu + sigma * np.array([0.1, 0.7, 2.5])
+    logit_F = (GenPareto.logcdf(x, *params) - GenPareto.logsf(x, *params)).eval()
+    np.testing.assert_allclose(GenPareto.ppf_logit(logit_F, *params).eval(), x, rtol=1e-9)
+
+
+def test_ppf_logit_is_stable_in_the_upper_tail():
+    params = make_params(0.0, 1.0, 0.2, dtype="float64")  # unbounded
+    y = np.array([40.0, 80.0, 120.0])  # expit(y) rounds to 1.0, so ppf(expit(y)) would saturate
+    xt = GenPareto.ppf_logit(y, *params).eval()
+    assert np.all(np.isfinite(xt))
+    assert np.all(np.diff(xt) > 0)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_genpareto.py
+++ b/tests/test_genpareto.py
@@ -21,6 +21,33 @@ import pytest
 import scipy.stats.distributions as sp
 
 from pytensor_distributions import genpareto as GenPareto
+from tests.helper_scipy import make_params, run_distribution_tests
+
+
+@pytest.mark.parametrize(
+    "params, sp_params",
+    [
+        ([0.0, 1.0, 0.1], {"c": 0.1, "loc": 0.0, "scale": 1.0}),
+        ([0.0, 1.0, 0.2], {"c": 0.2, "loc": 0.0, "scale": 1.0}),
+        ([1.0, 2.0, 0.0], {"c": 0.0, "loc": 1.0, "scale": 2.0}),
+        ([2.0, 0.5, -0.3], {"c": -0.3, "loc": 2.0, "scale": 0.5}),
+        ([0.0, 2.0, -0.1], {"c": -0.1, "loc": 0.0, "scale": 2.0}),
+    ],
+)
+def test_genpareto_vs_scipy(params, sp_params):
+    """Full distribution, moment and L-moment suite against scipy.genpareto."""
+    mu, sigma, xi = params
+    p_params = make_params(*params, dtype="float64")
+    upper = mu - sigma / xi if xi < 0 else float("inf")
+    run_distribution_tests(
+        p_dist=GenPareto,
+        sp_dist=sp.genpareto,
+        p_params=p_params,
+        sp_params=sp_params,
+        support=(mu, upper),
+        name="genpareto",
+        use_quantiles_for_rvs=True,
+    )
 
 
 def _gpd_ref_logp(value, mu, sigma, xi):

--- a/tests/test_genpareto.py
+++ b/tests/test_genpareto.py
@@ -1,0 +1,197 @@
+#   Copyright 2020 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from decimal import Decimal, getcontext
+
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+import scipy.stats.distributions as sp
+
+from pytensor_distributions import genpareto as GenPareto
+
+
+def _gpd_ref_logp(value, mu, sigma, xi):
+    """100-digit GPD logp from the exact margin ``s = 1 + xi*z``."""
+    getcontext().prec = 100
+    z = (Decimal(value) - mu) / sigma
+    log_s = (1 + xi * z).ln()
+    return -sigma.ln() - (1 + 1 / xi) * log_s
+
+
+def _gpd_ref_grad(value, params, which):
+    """High-precision central difference d logp / d ``which``."""
+    h = abs(params[which]) * Decimal("1e-22") or Decimal("1e-22")
+    hi = dict(params, **{which: params[which] + h})
+    lo = dict(params, **{which: params[which] - h})
+    return (_gpd_ref_logp(value, **hi) - _gpd_ref_logp(value, **lo)) / (2 * h)
+
+
+def test_functional_api_is_self_consistent():
+    x = np.array([0.3, 1.0, 3.0])
+    params = (0.0, 1.0, 0.2)
+
+    np.testing.assert_allclose(
+        GenPareto.cdf(x, *params).eval(), np.exp(GenPareto.logcdf(x, *params).eval())
+    )
+    np.testing.assert_allclose(
+        GenPareto.pdf(x, *params).eval(), np.exp(GenPareto.logpdf(x, *params).eval())
+    )
+    np.testing.assert_allclose(
+        GenPareto.sf(x, *params).eval(), np.exp(GenPareto.logsf(x, *params).eval())
+    )
+    np.testing.assert_allclose(
+        GenPareto.cdf(x, *params).eval() + GenPareto.sf(x, *params).eval(), 1.0, atol=1e-9
+    )
+
+    q = np.array([0.1, 0.5, 0.9])
+    np.testing.assert_allclose(
+        GenPareto.isf(q, *params).eval(), GenPareto.ppf(1 - q, *params).eval()
+    )
+    assert np.all(np.isnan(GenPareto.ppf(np.array([-0.1, 1.1]), *params).eval()))
+    np.testing.assert_allclose(float(GenPareto.ppf(0.0, *params).eval()), 0.0)
+
+
+def test_rvs_shape_dtype_and_random_state():
+    params = (0.0, 1.0, 0.2)
+    draws = GenPareto.rvs(
+        *params, size=(4, 3), random_state=pytensor.shared(np.random.default_rng(0))
+    )
+    out = draws.eval()
+    assert out.shape == (4, 3) and out.dtype == np.float64
+    assert np.all(out >= 0.0)
+
+    same = GenPareto.rvs(
+        *params, size=(4, 3), random_state=pytensor.shared(np.random.default_rng(0))
+    ).eval()
+    diff = GenPareto.rvs(
+        *params, size=(4, 3), random_state=pytensor.shared(np.random.default_rng(9))
+    ).eval()
+    np.testing.assert_array_equal(out, same)
+    assert not np.array_equal(out, diff)
+
+
+def test_logp_logcdf_at_infinity():
+    x = pt.constant(np.inf)
+    xi = pt.constant(np.array([-0.5, 0.0, 0.5]))
+    assert np.all(GenPareto.logpdf(x, 0.0, 1.0, xi).eval() == -np.inf)
+    assert np.all(GenPareto.logcdf(x, 0.0, 1.0, xi).eval() == 0.0)
+
+
+def test_ppf_endpoints():
+    xi = np.array([-0.5, 0.0, 0.5])
+    with np.errstate(divide="ignore"):
+        expected_hi = np.where(xi < 0, 1.0 - 2.0 / xi, np.inf)
+    assert np.all(GenPareto.ppf(0.0, 1.0, 2.0, xi).eval() == 1.0)
+    np.testing.assert_allclose(GenPareto.ppf(1.0, 1.0, 2.0, xi).eval(), expected_hi)
+
+
+def test_ppf_outside_unit_interval_is_nan():
+    for q in (-0.1, 1.1):
+        assert np.isnan(GenPareto.ppf(q, 0.0, 1.0, 0.2).eval())
+
+
+@pytest.mark.parametrize("xi", [1.5, 5.0])
+def test_heavy_tail_logpdf_logcdf_ppf_match_scipy(xi):
+    mu, sigma = 0.0, 1.3
+    x = np.array([0.5, 2.0, 10.0, 1e4])
+    np.testing.assert_allclose(
+        GenPareto.logpdf(x, mu, sigma, xi).eval(),
+        sp.genpareto.logpdf(x, c=xi, loc=mu, scale=sigma),
+        rtol=1e-10,
+    )
+    np.testing.assert_allclose(
+        GenPareto.logcdf(x, mu, sigma, xi).eval(),
+        sp.genpareto.logcdf(x, c=xi, loc=mu, scale=sigma),
+        rtol=1e-10,
+    )
+    q = np.array([0.1, 0.5, 0.9, 0.99, 0.999])
+    np.testing.assert_allclose(
+        GenPareto.ppf(q, mu, sigma, xi).eval(),
+        sp.genpareto.ppf(q, c=xi, loc=mu, scale=sigma),
+        rtol=1e-9,
+    )
+
+
+def test_logsf_tail_is_stable():
+    x = np.array([1e2, 1e4, 1e6, 1e8])
+    for xi in (0.1, 0.3, 0.7):
+        got = GenPareto.logsf(x, 0.0, 1.0, xi).eval()
+        ref = sp.genpareto.logsf(x, c=xi)
+        np.testing.assert_allclose(got, ref, rtol=1e-12)
+
+
+def test_isf_keeps_the_upper_tail():
+    x = np.array([1e-8, 1e-12, 1e-15])
+    xi = pt.constant(0.0)
+    isf_val = GenPareto.isf(x, 0.0, 1.0, xi).eval()
+    np.testing.assert_allclose(isf_val, -np.log(x), rtol=1e-12)
+    naive = GenPareto.ppf(1 - x, 0.0, 1.0, xi).eval()
+    assert abs(isf_val[-1] - -np.log(x[-1])) < abs(naive[-1] - -np.log(x[-1]))
+
+
+def test_boundary_logp_value_holds_but_gradient_tracks_the_margin():
+    mu, sigma, xi = 0.4, 1.3, -0.3
+    eps = np.finfo(np.float64).eps
+    margins = [1e-2, 1e-6, 1e-12]
+
+    v, sig, xs = (pt.dscalar(n) for n in ("v", "sig", "xs"))
+    logp = GenPareto.logpdf(v, mu, sig, xs)
+    fn = pytensor.function([v, sig, xs], [logp, pt.grad(logp, sig), pt.grad(logp, xs)])
+
+    params = {"mu": Decimal(mu), "sigma": Decimal(sigma), "xi": Decimal(xi)}
+    prev_logp = np.inf
+    for s_target in margins:
+        value = mu + sigma * ((s_target - 1) / xi)
+        logp_f, *grads_f = (float(o) for o in fn(value, sigma, xi))
+        logp_ref = _gpd_ref_logp(value, **params)
+
+        assert np.isfinite(logp_f), s_target
+        assert all(np.isfinite(g) for g in grads_f), s_target
+        assert logp_f < prev_logp, s_target
+        prev_logp = logp_f
+        assert abs((Decimal(logp_f) - logp_ref) / logp_ref) < 1e-4, s_target
+
+        grad_bound = 100 * eps / s_target
+        for name, g in zip(["sigma", "xi"], grads_f):
+            g_ref = _gpd_ref_grad(value, params, name)
+            rel = abs((Decimal(g) - g_ref) / g_ref)
+            assert np.sign(g) == np.sign(float(g_ref)), (name, s_target)
+            assert rel < grad_bound, (name, s_target, float(rel))
+
+
+def test_logp_gradient_is_continuous_through_xi_zero():
+    xi = pt.dscalar("xi")
+    logp = GenPareto.logpdf(pt.constant(2.3), 0.0, 1.0, xi)
+    fn = pytensor.function([xi], [logp, pt.grad(logp, xi)], on_unused_input="ignore")
+
+    _, grad0 = fn(0.0)
+    assert np.isfinite(grad0)
+    _, grad_minus = fn(-1e-7)
+    _, grad_plus = fn(1e-7)
+    assert abs(grad_minus - grad0) < 1e-5
+    assert abs(grad_plus - grad0) < 1e-5
+    h = 1e-5
+    fd = (fn(h)[0] - fn(-h)[0]) / (2 * h)
+    assert abs(grad0 - fd) < 1e-5
+
+
+def test_value_continuous_through_xi_zero():
+    value = np.linspace(0.05, 6.0, 50)
+    lp0 = GenPareto.logpdf(value, 0.0, 2.0, 0.0).eval()
+    for xi in (1e-9, -1e-9, 1e-6):
+        lp = GenPareto.logpdf(value, 0.0, 2.0, xi).eval()
+        np.testing.assert_allclose(lp, lp0, atol=1e-5)
+    np.testing.assert_allclose(lp0, sp.expon.logpdf(value, scale=2.0), atol=1e-12)

--- a/tests/test_genpareto.py
+++ b/tests/test_genpareto.py
@@ -34,6 +34,30 @@ def test_ppf_logit_is_stable_in_the_upper_tail():
     assert np.all(np.diff(xt) > 0)
 
 
+@pytest.mark.parametrize("xi, expected", [(-2.0, np.inf), (-1.0, 0.0), (-0.5, -np.inf)])
+def test_logpdf_at_finite_upper_endpoint(xi, expected):
+    """Density at the finite upper endpoint matches scipy.
+
+    It diverges for xi < -1, equals 1/sigma (logpdf 0 with sigma = 1) at xi = -1, and is
+    0 (logpdf -inf) for -1 < xi < 0.
+    """
+    mu, sigma = 0.0, 1.0
+    x_F = mu - sigma / xi
+    val = GenPareto.logpdf(np.array(x_F), *make_params(mu, sigma, xi)).eval()
+    assert val == expected
+    if xi < -1:  # the mode is that diverging endpoint
+        assert np.isclose(GenPareto.mode(*make_params(mu, sigma, xi)).eval(), x_F)
+
+
+def test_invalid_sigma_gives_nonfinite_logpdf():
+    """A non-positive sigma yields a non-finite logpdf, never a plausible density.
+
+    Parameter validation is the consuming wrapper's job (e.g. pymc's check_parameters).
+    """
+    val = GenPareto.logpdf(np.array(0.5), *make_params(0.0, -1.0, 0.2)).eval()
+    assert not np.isfinite(val)
+
+
 @pytest.mark.parametrize(
     "params, sp_params",
     [
@@ -42,6 +66,7 @@ def test_ppf_logit_is_stable_in_the_upper_tail():
         ([1.0, 2.0, 0.0], {"c": 0.0, "loc": 1.0, "scale": 2.0}),
         ([2.0, 0.5, -0.3], {"c": -0.3, "loc": 2.0, "scale": 0.5}),
         ([0.0, 2.0, -0.1], {"c": -0.1, "loc": 0.0, "scale": 2.0}),
+        ([0.0, 1.0, -2.0], {"c": -2.0, "loc": 0.0, "scale": 1.0}),  # xi < -1: bounded, mode at xF
     ],
 )
 def test_genpareto_vs_scipy(params, sp_params):

--- a/tests/test_genpareto.py
+++ b/tests/test_genpareto.py
@@ -257,3 +257,13 @@ def test_value_continuous_through_xi_zero():
         lp = GenPareto.logpdf(value, 0.0, 2.0, xi).eval()
         np.testing.assert_allclose(lp, lp0, atol=1e-5)
     np.testing.assert_allclose(lp0, sp.expon.logpdf(value, scale=2.0), atol=1e-12)
+
+
+@pytest.mark.parametrize("dtype", ["float64", "float32"])
+def test_summary_stats_follow_input_dtype(dtype):
+    """mean/var/std/skewness/kurtosis/entropy/median/lmoments keep the input dtype."""
+    params = [pt.scalar(name, dtype=dtype) for name in ("mu", "sigma", "xi")]
+    names = ["mean", "var", "std", "skewness", "kurtosis", "entropy"]
+    names += ["median", "lmoment1", "lmoment2", "lmoment3", "lmoment4"]
+    for name in names:
+        assert getattr(GenPareto, name)(*params).dtype == dtype, name


### PR DESCRIPTION
## Summary

Adds two continuous distributions as PyTensor-only modules:

- `genpareto` — the Generalized Pareto distribution (GPD), matching scipy's `genpareto` (`c = ξ`).
- `extgenpareto` — the Naveau et al. (2016) Type-1 extended GPD, `F = H**κ` with `H` the
  GPD CDF; `κ = 1` recovers the GPD.

Each exposes the full module surface: `logpdf` / `logcdf` / `logsf` / `cdf` / `pdf` / `sf` /
`ppf` / `isf` / `rvs`, the moment/L-moment/entropy suite (`mean` / `median` / `mode` / `var` /
`std` / `skewness` / `kurtosis` / `entropy` / `lmoment1`–`4`), and `ppf_logit`.

## Numerical notes

- The kernels stay accurate deep into both tails and through `ξ = 0`. The forward
  `m = log1p(ξz)/ξ` and its inverse `z = (exp(ξm) − 1)/ξ` (the quantile direction) are
  each evaluated by a short Taylor series near 0: the value is accurate either way, but
  the naive `f(u)/u` divided difference makes the autodiff *gradient* catastrophically
  cancel as `u → 0`, and the series avoids that.
- `ppf_logit(y)` is `ppf(expit(y))` evaluated without forming `expit(y)`, so it survives
  tail saturation — the inverse for a logit-CDF (PIT) reparametrization used to sample
  these heavy-tailed distributions as latents.
- ExtGPD moments use Beta-function closed forms from `X = μ + (σ/ξ)(W**(-ξ) − 1)`,
  `W ~ Beta(1, κ)`, with finite digamma limits at `ξ = 0` and a closed-form entropy; all
  reduce to the GPD at `κ = 1`.

## Tests

- `genpareto`: full distribution + moment + L-moment suite vs `scipy.genpareto`
  (`run_distribution_tests`).
- `extgenpareto` (not in scipy): vs quadrature of its own pdf, sample L-moments, the
  `κ = 1` reduction to `genpareto`, and high-precision reference checks.

Originated in pymc-devs/pymc-extras#689.
