### PR TITLE
Add lmoments

### DIFF
--- a/pytensor_distributions/asymmetriclaplace.py
+++ b/pytensor_distributions/asymmetriclaplace.py
@@ -36,6 +36,39 @@ def kurtosis(mu, b, kappa):
     return 6.0 * (1 + pt.power(kappa, 8)) / pt.power(1 + pt.power(kappa, 4), 2)
 
 
+def lmoment1(mu, b, kappa):
+    return mean(mu, b, kappa)
+
+
+def lmoment2(mu, b, kappa):
+    shape = pt.broadcast_arrays(mu, b, kappa)[0]
+    kappa_sq = kappa**2
+    num = b * (1.0 + kappa_sq + kappa_sq**2)
+    denom = 2.0 * kappa * (1.0 + kappa_sq)
+    return pt.full_like(shape, num / denom)
+
+
+def lmoment3(mu, b, kappa):
+    shape = pt.broadcast_arrays(mu, b, kappa)[0]
+    kappa_sq = kappa**2
+    kappa_four = kappa_sq**2
+    kappa_six = kappa_sq * kappa_four
+    num = 1.0 + 2.0 * kappa_sq - 2.0 * kappa_four - kappa_six
+    denom = 3.0 * (1.0 + 2.0 * kappa_sq + 2.0 * kappa_four + kappa_six)
+    return pt.full_like(shape, num / denom)
+
+
+def lmoment4(mu, b, kappa):
+    shape = pt.broadcast_arrays(mu, b, kappa)[0]
+    kappa_sq = kappa**2
+    kappa_four = kappa_sq**2
+    kappa_six = kappa_sq * kappa_four
+    kappa_eight = kappa_four**2
+    num = 1.0 + 3.0 * kappa_sq + 9.0 * kappa_four + 3.0 * kappa_six + kappa_eight
+    denom = 6.0 * (1.0 + 3.0 * kappa_sq + 4.0 * kappa_four + 3.0 * kappa_six + kappa_eight)
+    return pt.full_like(shape, num / denom)
+
+
 def entropy(mu, b, kappa):
     return 1 + pt.log(kappa + 1 / kappa) + pt.log(b)
 

--- a/pytensor_distributions/bernoulli.py
+++ b/pytensor_distributions/bernoulli.py
@@ -33,6 +33,22 @@ def kurtosis(p):
     return (1 - 6 * p * (1 - p)) / (p * (1 - p))
 
 
+def lmoment1(p):
+    return mean(p)
+
+
+def lmoment2(p):
+    return p * (1 - p)
+
+
+def lmoment3(p):
+    return 1 - 2 * p
+
+
+def lmoment4(p):
+    return 1 - 5 * p * (1 - p)
+
+
 def entropy(p):
     q = 1 - p
     return -xlogx(p) - xlogx(q)

--- a/pytensor_distributions/beta.py
+++ b/pytensor_distributions/beta.py
@@ -4,6 +4,7 @@ from pytensor.tensor.special import betaln
 from pytensor.tensor.xlogx import xlogy0
 
 from pytensor_distributions.helper import ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 
 
 def mean(alpha, beta):
@@ -52,6 +53,22 @@ def kurtosis(alpha, beta):
         / (prod * (psc + 2) * (psc + 3))
     )
     return result
+
+
+def lmoment1(alpha, beta):
+    return mean(alpha, beta)
+
+
+def lmoment2(alpha, beta):
+    return _lmoments(ppf, alpha, beta, r=2)
+
+
+def lmoment3(alpha, beta):
+    return _lmoments(ppf, alpha, beta, r=3)
+
+
+def lmoment4(alpha, beta):
+    return _lmoments(ppf, alpha, beta, r=4)
 
 
 def entropy(alpha, beta):

--- a/pytensor_distributions/betabinomial.py
+++ b/pytensor_distributions/betabinomial.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import cdf_bounds, discrete_entropy
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.optimization import find_ppf_discrete
 
 
@@ -74,6 +75,22 @@ def kurtosis(n, alpha, beta):
     right -= (3 * alpha_beta_product * n * (6 - n)) / alpha_beta_sum
     right -= (18 * alpha_beta_product * n**2) / (alpha_beta_sum) ** 2
     return (left * right) - 3
+
+
+def lmoment1(n, alpha, beta):
+    return mean(n, alpha, beta)
+
+
+def lmoment2(n, alpha, beta):
+    return _lmoments(ppf, n, alpha, beta, r=2)
+
+
+def lmoment3(n, alpha, beta):
+    return _lmoments(ppf, n, alpha, beta, r=3)
+
+
+def lmoment4(n, alpha, beta):
+    return _lmoments(ppf, n, alpha, beta, r=4)
 
 
 def entropy(n, alpha, beta):

--- a/pytensor_distributions/betascaled.py
+++ b/pytensor_distributions/betascaled.py
@@ -4,6 +4,7 @@ from pytensor.tensor.special import betaln
 from pytensor.tensor.xlogx import xlogy0
 
 from pytensor_distributions.helper import ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 
 
 def mean(alpha, beta, lower, upper):
@@ -56,6 +57,22 @@ def kurtosis(alpha, beta, lower, upper):
         / (prod * (psc + 2) * (psc + 3))
     )
     return result
+
+
+def lmoment1(alpha, beta, lower, upper):
+    return mean(alpha, beta, lower, upper)
+
+
+def lmoment2(alpha, beta, lower, upper):
+    return _lmoments(ppf, alpha, beta, lower, upper, r=2)
+
+
+def lmoment3(alpha, beta, lower, upper):
+    return _lmoments(ppf, alpha, beta, lower, upper, r=3)
+
+
+def lmoment4(alpha, beta, lower, upper):
+    return _lmoments(ppf, alpha, beta, lower, upper, r=4)
 
 
 def entropy(alpha, beta, lower, upper):

--- a/pytensor_distributions/binomial.py
+++ b/pytensor_distributions/binomial.py
@@ -2,6 +2,7 @@ import pytensor.tensor as pt
 from pytensor.tensor.xlogx import xlogy0
 
 from pytensor_distributions.helper import cdf_bounds, discrete_entropy
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.optimization import find_ppf_discrete
 
 
@@ -32,6 +33,22 @@ def skewness(n, p):
 
 def kurtosis(n, p):
     return (1 - 6 * p * (1 - p)) / (n * p * (1 - p))
+
+
+def lmoment1(n, p):
+    return mean(n, p)
+
+
+def lmoment2(n, p):
+    return _lmoments(ppf, n, p, r=2)
+
+
+def lmoment3(n, p):
+    return _lmoments(ppf, n, p, r=3)
+
+
+def lmoment4(n, p):
+    return _lmoments(ppf, n, p, r=4)
 
 
 def entropy(n, p):

--- a/pytensor_distributions/cauchy.py
+++ b/pytensor_distributions/cauchy.py
@@ -36,6 +36,26 @@ def kurtosis(alpha, beta):
     return pt.full_like(alpha_b, pt.nan)
 
 
+def lmoment1(alpha, beta):
+    alpha_b, _ = pt.broadcast_arrays(alpha, beta)
+    return pt.full_like(alpha_b, pt.nan)
+
+
+def lmoment2(alpha, beta):
+    alpha_b, _ = pt.broadcast_arrays(alpha, beta)
+    return pt.full_like(alpha_b, pt.nan)
+
+
+def lmoment3(alpha, beta):
+    alpha_b, _ = pt.broadcast_arrays(alpha, beta)
+    return pt.full_like(alpha_b, pt.nan)
+
+
+def lmoment4(alpha, beta):
+    alpha_b, _ = pt.broadcast_arrays(alpha, beta)
+    return pt.full_like(alpha_b, pt.nan)
+
+
 def entropy(alpha, beta):
     _, beta_b = pt.broadcast_arrays(alpha, beta)
     return pt.log(4 * pt.pi * beta_b)

--- a/pytensor_distributions/chisquared.py
+++ b/pytensor_distributions/chisquared.py
@@ -2,6 +2,7 @@ import pytensor.tensor as pt
 from pytensor.tensor.xlogx import xlogy0
 
 from pytensor_distributions.helper import cdf_bounds, ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 
 
 def mean(nu):
@@ -30,6 +31,22 @@ def skewness(nu):
 
 def kurtosis(nu):
     return 12 / nu
+
+
+def lmoment1(nu):
+    return mean(nu)
+
+
+def lmoment2(nu):
+    return _lmoments(ppf, nu, r=2)
+
+
+def lmoment3(nu):
+    return _lmoments(ppf, nu, r=3)
+
+
+def lmoment4(nu):
+    return _lmoments(ppf, nu, r=4)
 
 
 def entropy(nu):

--- a/pytensor_distributions/discreteuniform.py
+++ b/pytensor_distributions/discreteuniform.py
@@ -34,6 +34,25 @@ def kurtosis(lower, upper):
     return -(6 * (n**2 + 1)) / (5 * (n**2 - 1))
 
 
+def lmoment1(lower, upper):
+    return mean(lower, upper)
+
+
+def lmoment2(lower, upper):
+    n = upper - lower + 1
+    return (n**2 - 1) / (6 * n)
+
+
+def lmoment3(lower, upper):
+    shape = pt.broadcast_arrays(lower, upper)[0]
+    return pt.zeros_like(shape)
+
+
+def lmoment4(lower, upper):
+    n = upper - lower + 1
+    return -1.0 / (n**2)
+
+
 def entropy(lower, upper):
     return discrete_entropy(lower, upper + 1, logpdf, lower, upper)
 

--- a/pytensor_distributions/exgaussian.py
+++ b/pytensor_distributions/exgaussian.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import continuous_entropy, logdiffexp
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.normal import logcdf as normal_logcdf
 from pytensor_distributions.normal import logpdf as normal_logpdf
 from pytensor_distributions.optimization import find_ppf
@@ -41,6 +42,22 @@ def kurtosis(mu, sigma, nu):
     nus2 = pt.square(nu / sigma)
     opnus2 = 1.0 + nus2
     return 6.0 * pt.square(nus2) * pt.pow(opnus2, -2)
+
+
+def lmoment1(mu, sigma, nu):
+    return mean(mu, sigma, nu)
+
+
+def lmoment2(mu, sigma, nu):
+    return _lmoments(ppf, mu, sigma, nu, r=2)
+
+
+def lmoment3(mu, sigma, nu):
+    return _lmoments(ppf, mu, sigma, nu, r=3)
+
+
+def lmoment4(mu, sigma, nu):
+    return _lmoments(ppf, mu, sigma, nu, r=4)
 
 
 def entropy(mu, sigma, nu):

--- a/pytensor_distributions/exponential.py
+++ b/pytensor_distributions/exponential.py
@@ -34,6 +34,25 @@ def kurtosis(lam):
     return pt.full_like(shape, 6.0)
 
 
+def lmoment1(lam):
+    return mean(lam)
+
+
+def lmoment2(lam):
+    shape = pt.broadcast_arrays(lam)[0]
+    return pt.full_like(shape, 1 / lam * 0.5)
+
+
+def lmoment3(lam):
+    shape = pt.broadcast_arrays(lam)[0]
+    return pt.full_like(shape, 1 / 3)
+
+
+def lmoment4(lam):
+    shape = pt.broadcast_arrays(lam)[0]
+    return pt.full_like(shape, 1 / 6)
+
+
 def entropy(lam):
     return 1.0 - pt.log(lam)
 

--- a/pytensor_distributions/gamma.py
+++ b/pytensor_distributions/gamma.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 
 
 def mean(alpha, beta):
@@ -31,6 +32,22 @@ def skewness(alpha, beta):
 def kurtosis(alpha, beta):
     shape = pt.broadcast_arrays(alpha, beta)[0]
     return pt.full_like(shape, 6 / alpha)
+
+
+def lmoment1(alpha, beta):
+    return mean(alpha, beta)
+
+
+def lmoment2(alpha, beta):
+    return _lmoments(ppf, alpha, beta, r=2)
+
+
+def lmoment3(alpha, beta):
+    return _lmoments(ppf, alpha, beta, r=3)
+
+
+def lmoment4(alpha, beta):
+    return _lmoments(ppf, alpha, beta, r=4)
 
 
 def entropy(alpha, beta):

--- a/pytensor_distributions/geometric.py
+++ b/pytensor_distributions/geometric.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import cdf_bounds, ppf_bounds_disc
+from pytensor_distributions.lmoments import _lmoments
 
 
 def mean(p):
@@ -29,6 +30,22 @@ def skewness(p):
 
 def kurtosis(p):
     return 6 + (p**2) / (1 - p)
+
+
+def lmoment1(p):
+    return mean(p)
+
+
+def lmoment2(p):
+    return (1 - p) / (p * (2 - p))
+
+
+def lmoment3(p):
+    return _lmoments(ppf, p, r=3)
+
+
+def lmoment4(p):
+    return _lmoments(ppf, p, r=4)
 
 
 def entropy(p):

--- a/pytensor_distributions/gumbel.py
+++ b/pytensor_distributions/gumbel.py
@@ -36,6 +36,28 @@ def kurtosis(mu, beta):
     return pt.full_like(shape, 2.4)
 
 
+def lmoment1(mu, beta):
+    return mean(mu, beta)
+
+
+def lmoment2(mu, beta):
+    shape = pt.broadcast_arrays(mu, beta)[0]
+    # $\beta \ln 2$
+    return pt.full_like(shape, beta * 0.6931471805599453)
+
+
+def lmoment3(mu, beta):
+    shape = pt.broadcast_arrays(mu, beta)[0]
+    # $\frac{\ln(9/8)}{\ln 2} \approx 0.1699$
+    return pt.full_like(shape, 0.1699250014423124)
+
+
+def lmoment4(mu, beta):
+    shape = pt.broadcast_arrays(mu, beta)[0]
+    # $\frac{16 \ln 2 - 10 \ln 3}{2 \ln 2} \approx 0.1504$
+    return pt.full_like(shape, 0.1503754942004245)
+
+
 def entropy(mu, beta):
     shape = pt.broadcast_arrays(mu, beta)[0]
     return pt.full_like(shape, pt.log(beta) + 1 + pt.euler_gamma)

--- a/pytensor_distributions/halfcauchy.py
+++ b/pytensor_distributions/halfcauchy.py
@@ -31,6 +31,22 @@ def kurtosis(beta):
     return pt.full_like(beta, pt.nan)
 
 
+def lmoment1(beta):
+    return mean(beta)
+
+
+def lmoment2(beta):
+    return pt.full_like(beta, pt.inf)
+
+
+def lmoment3(beta):
+    return pt.full_like(beta, pt.inf)
+
+
+def lmoment4(beta):
+    return pt.full_like(beta, pt.inf)
+
+
 def entropy(beta):
     return pt.log(2 * pt.pi * beta)
 

--- a/pytensor_distributions/halfnormal.py
+++ b/pytensor_distributions/halfnormal.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 
 
 def mean(sigma):
@@ -29,6 +30,23 @@ def skewness(sigma):
 
 def kurtosis(sigma):
     return pt.full_like(sigma, 0.8691773)
+
+
+def lmoment1(sigma):
+    return mean(sigma)
+
+
+def lmoment2(sigma):
+    # sigma * (2 - sqrt(2)) / sqrt(pi)
+    return sigma * 0.3304946062926472
+
+
+def lmoment3(sigma):
+    return _lmoments(ppf, sigma, r=3)
+
+
+def lmoment4(sigma):
+    return _lmoments(ppf, sigma, r=4)
 
 
 def entropy(sigma):

--- a/pytensor_distributions/halfstudentt.py
+++ b/pytensor_distributions/halfstudentt.py
@@ -6,6 +6,7 @@ from pytensor_distributions.halfnormal import cdf as halfnormal_cdf
 from pytensor_distributions.halfnormal import entropy as halfnormal_entropy
 from pytensor_distributions.halfnormal import logpdf as halfnormal_logpdf
 from pytensor_distributions.helper import cdf_bounds, ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 
 
 def mean(nu, sigma):
@@ -58,6 +59,22 @@ def skewness(nu, sigma):
 def kurtosis(nu, sigma):
     nu_b, _ = pt.broadcast_arrays(nu, sigma)
     return pt.full_like(nu_b, pt.nan)
+
+
+def lmoment1(nu, sigma):
+    return mean(nu, sigma)
+
+
+def lmoment2(nu, sigma):
+    return pt.switch(nu > 2, _lmoments(ppf, nu, sigma, r=2), pt.inf)
+
+
+def lmoment3(nu, sigma):
+    return pt.switch(nu > 3, _lmoments(ppf, nu, sigma, r=3), pt.inf)
+
+
+def lmoment4(nu, sigma):
+    return pt.switch(nu > 4, _lmoments(ppf, nu, sigma, r=4), pt.inf)
 
 
 def entropy(nu, sigma):

--- a/pytensor_distributions/hypergeometric.py
+++ b/pytensor_distributions/hypergeometric.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import cdf_bounds, discrete_entropy
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.optimization import find_ppf_discrete
 
 
@@ -52,6 +53,22 @@ def kurtosis(N, k, n):
     ) * m * (5 * N - 6)
     den = k * n * (N - n) * m * (N - 2) * (N - 3)
     return num / den
+
+
+def lmoment1(N, k, n):
+    return mean(N, k, n)
+
+
+def lmoment2(N, k, n):
+    return _lmoments(ppf, N, k, n, r=2)
+
+
+def lmoment3(N, k, n):
+    return _lmoments(ppf, N, k, n, r=3)
+
+
+def lmoment4(N, k, n):
+    return _lmoments(ppf, N, k, n, r=4)
 
 
 def entropy(N, k, n):

--- a/pytensor_distributions/inversegamma.py
+++ b/pytensor_distributions/inversegamma.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import cdf_bounds, ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 
 
 def mean(alpha, beta):
@@ -29,6 +30,22 @@ def skewness(alpha, beta):
 
 def kurtosis(alpha, beta):
     return pt.switch(pt.gt(alpha, 4), 6 * (5 * alpha - 11) / ((alpha - 3) * (alpha - 4)), pt.nan)
+
+
+def lmoment1(alpha, beta):
+    return mean(alpha, beta)
+
+
+def lmoment2(alpha, beta):
+    return pt.switch(pt.gt(alpha, 1), _lmoments(ppf, alpha, beta, r=2), pt.inf)
+
+
+def lmoment3(alpha, beta):
+    return pt.switch(pt.gt(alpha, 1), _lmoments(ppf, alpha, beta, r=3), pt.inf)
+
+
+def lmoment4(alpha, beta):
+    return pt.switch(pt.gt(alpha, 1), _lmoments(ppf, alpha, beta, r=4), pt.inf)
 
 
 def entropy(alpha, beta):

--- a/pytensor_distributions/kumaraswamy.py
+++ b/pytensor_distributions/kumaraswamy.py
@@ -1,4 +1,5 @@
 import pytensor.tensor as pt
+from pytensor.tensor.special import betaln
 from pytensor.tensor.xlogx import xlogy0
 
 from pytensor_distributions.helper import cdf_bounds, ppf_bounds_cont, sf_bounds
@@ -43,6 +44,36 @@ def kurtosis(a, b):
     m_3 = b * pt.exp(pt.gammaln(1 + 3 / a) + pt.gammaln(b) - pt.gammaln(1 + 3 / a + b))
     m_4 = b * pt.exp(pt.gammaln(1 + 4 / a) + pt.gammaln(b) - pt.gammaln(1 + 4 / a + b))
     return (m_4 + m_1 * (-4 * m_3 + m_1 * (6 * m_2 - 3 * m_1**2))) / variance**2 - 3
+
+
+def lmoment1(a, b):
+    return mean(a, b)
+
+
+def lmoment2(a, b):
+    inv_a = 1.0 / a
+    term1 = b * pt.exp(betaln(1.0 + inv_a, b))
+    term2 = 2.0 * b * pt.exp(betaln(1.0 + inv_a, 2.0 * b))
+    return term1 - term2
+
+
+def lmoment3(a, b):
+    inv_a = 1.0 / a
+    l2 = lmoment2(a, b)
+    term1 = b * pt.exp(betaln(1.0 + inv_a, b))
+    term2 = 6.0 * b * pt.exp(betaln(1.0 + inv_a, 2.0 * b))
+    term3 = 6.0 * b * pt.exp(betaln(1.0 + inv_a, 3.0 * b))
+    return (term1 - term2 + term3) / l2
+
+
+def lmoment4(a, b):
+    inv_a = 1.0 / a
+    l2 = lmoment2(a, b)
+    term1 = b * pt.exp(betaln(1.0 + inv_a, b))
+    term2 = 12.0 * b * pt.exp(betaln(1.0 + inv_a, 2.0 * b))
+    term3 = 30.0 * b * pt.exp(betaln(1.0 + inv_a, 3.0 * b))
+    term4 = 20.0 * b * pt.exp(betaln(1.0 + inv_a, 4.0 * b))
+    return (term1 - term2 + term3 - term4) / l2
 
 
 def entropy(a, b):

--- a/pytensor_distributions/laplace.py
+++ b/pytensor_distributions/laplace.py
@@ -38,6 +38,25 @@ def kurtosis(mu, b):
     return pt.full_like(shape, 3.0)
 
 
+def lmoment1(mu, b):
+    return mean(mu, b)
+
+
+def lmoment2(mu, b):
+    shape = pt.broadcast_arrays(mu, b)[0]
+    return pt.full_like(shape, b * 0.75)
+
+
+def lmoment3(mu, b):
+    shape = pt.broadcast_arrays(mu, b)[0]
+    return pt.zeros_like(shape)
+
+
+def lmoment4(mu, b):
+    shape = pt.broadcast_arrays(mu, b)[0]
+    return pt.full_like(shape, 0.2361111111111111)
+
+
 def entropy(mu, b):
     _, b_b = pt.broadcast_arrays(mu, b)
     return pt.log(2.0 * b_b) + 1.0

--- a/pytensor_distributions/lmoments.py
+++ b/pytensor_distributions/lmoments.py
@@ -1,0 +1,143 @@
+import numpy as np
+import pytensor.tensor as pt
+
+
+def _shifted_legendre(r: int, u):
+    """
+    Shifted Legendre polynomial P*_{r-1}(u) on [0, 1] for r = 1, 2, 3, 4.
+
+    Parameters
+    ----------
+    r : int
+        L-moment order (1-indexed).
+    u : tensor
+        Evaluation points in [0, 1].
+
+    Notes
+    -----
+    .. math::
+        P*_0(u) = 1
+        P*_1(u) = 2u - 1
+        P*_2(u) = 6u^2 - 6u + 1
+        P*_3(u) = 20u^3 - 30u^2 + 12u - 1
+
+    Returns
+    -------
+    tensor
+    """
+    if r == 1:
+        return pt.ones_like(u)
+    elif r == 2:
+        return 2.0 * u - 1.0
+    elif r == 3:
+        return 6.0 * u**2 - 6.0 * u + 1.0
+    elif r == 4:
+        return 20.0 * u**3 - 30.0 * u**2 + 12.0 * u - 1.0
+    else:
+        raise NotImplementedError(f"Shifted Legendre polynomial not implemented for r={r}.")
+
+
+# Pre-compute GL nodes/weights for common n_points values so repeated calls
+# with the same n_points don't recompute them.
+_GL_CACHE = {}
+
+
+def _gl_nodes_weights(n_points: int) -> tuple[np.ndarray, np.ndarray]:
+    """Gauss-Legendre nodes and weights shifted to [0, 1]."""
+    if n_points not in _GL_CACHE:
+        nodes, weights = np.polynomial.legendre.leggauss(n_points)
+        _GL_CACHE[n_points] = ((nodes + 1.0) / 2.0, weights / 2.0)
+    return _GL_CACHE[n_points]
+
+
+def _lmoment_from_ppf(ppf_func, params, r=None, n_points=50):
+    """Compute the r-th L-moment by numerical integration of the PPF.
+
+    Parameters
+    ----------
+    ppf_func : callable
+        PPF (quantile function) with signature ppf(q, *params).
+    params : sequence of tensor
+        Distribution parameters.
+    r : int
+        L-moment order, 1 <= r <= 4.
+    n_points : int
+        Number of Gauss-Legendre quadrature nodes. Defaults to 50, which gives
+        accuracy equivalent to the trapezoidal rule at ~5000+ points for smooth
+        PPFs. Can typically be reduced to 20-30 without any loss in practice.
+
+    Returns
+    -------
+    tensor
+        The r-th L-moment.
+
+    Notes
+    -----
+    L-moments are computed via integration of the quantile function (PPF) against
+    shifted Legendre polynomials:
+
+    .. math::
+        lambda_r = int_0^1 Q(u) cdot P^*_{r-1}(u), du
+
+    where :math:`P^*_{r-1}` are the shifted Legendre polynomials on [0, 1] and
+    :math:`Q` = ppf.
+
+    Gauss-Legendre quadrature is used instead of the trapezoidal rule because
+    the integrand is smooth, allowing exponential convergence with far fewer
+    PPF evaluations. Endpoint singularity padding (eps) is also unnecessary
+    since GL nodes never fall on the boundary.
+
+    References
+    ----------
+    .. [1] Hosking, J.R.M. *L-moments: analysis and estimation of distributions
+        using linear combinations of order statistics*. 1990. Journal of the Royal
+        Statistical Society, Series B. https://doi.org/10.1111/j.2517-6161.1990.tb01775.x
+    """
+    np_nodes, np_weights = _gl_nodes_weights(n_points)
+    nodes = pt.as_tensor_variable(np_nodes, dtype="float64")
+    weights = pt.as_tensor_variable(np_weights, dtype="float64")
+
+    if len(params) == 1:
+        broadcast_shape = pt.as_tensor_variable(params[0])
+    else:
+        broadcast_shape = pt.broadcast_arrays(*params)[0]
+
+    # Reshape nodes/weights to broadcast over parameter dimensions:
+    # (n_points, 1, ..., 1) vs params of shape (param_shape,)
+    if broadcast_shape.ndim > 0:
+        expand = (-1,) + (1,) * broadcast_shape.ndim
+        nodes_bc = nodes.reshape(expand)
+        weights_bc = weights.reshape(expand)
+    else:
+        nodes_bc = nodes
+        weights_bc = weights
+
+    quantiles = ppf_func(nodes_bc, *params)
+    legendre_vals = _shifted_legendre(r, nodes_bc)
+
+    result = pt.sum(weights_bc * quantiles * legendre_vals, axis=0)
+
+    return pt.squeeze(result) if broadcast_shape.ndim == 0 else result
+
+
+def _lmoments(ppf_func, *params, r=None, n_points=50):
+    """Compute L-moments from 2 to 4 using the PPF and numerical integration.
+
+    r1 is the mean, so we omit it.
+    r2 is the second L-moment.
+    For third and fourth L-moments, we use the ratios.
+    tau3 = r3/r2 is the L-skewness
+    tau4 = r4/r2 is the L-kurtosis
+    """
+    if r == 2:
+        return _lmoment_from_ppf(ppf_func, params, r=2, n_points=n_points)
+    if r == 3:
+        l3 = _lmoment_from_ppf(ppf_func, params, r=3, n_points=n_points)
+        l2 = _lmoment_from_ppf(ppf_func, params, r=2, n_points=n_points)
+        return l3 / l2
+    if r == 4:
+        l4 = _lmoment_from_ppf(ppf_func, params, r=4, n_points=n_points)
+        l2 = _lmoment_from_ppf(ppf_func, params, r=2, n_points=n_points)
+        return l4 / l2
+    else:
+        raise NotImplementedError(f"L-moments not implemented for r={r}.")

--- a/pytensor_distributions/logistic.py
+++ b/pytensor_distributions/logistic.py
@@ -38,6 +38,25 @@ def kurtosis(mu, s):
     return pt.full_like(shape, 1.2)
 
 
+def lmoment1(mu, s):
+    return mean(mu, s)
+
+
+def lmoment2(mu, s):
+    shape = pt.broadcast_arrays(mu, s)[0]
+    return pt.full_like(shape, s)
+
+
+def lmoment3(mu, s):
+    shape = pt.broadcast_arrays(mu, s)[0]
+    return pt.zeros_like(shape)
+
+
+def lmoment4(mu, s):
+    shape = pt.broadcast_arrays(mu, s)[0]
+    return pt.full_like(shape, 1 / 6)
+
+
 def entropy(mu, s):
     shape = pt.broadcast_arrays(mu, s)[0]
     return pt.full_like(shape, pt.log(s) + 2)

--- a/pytensor_distributions/logitnormal.py
+++ b/pytensor_distributions/logitnormal.py
@@ -5,6 +5,7 @@ from pytensor_distributions.helper import (
     cdf_bounds,
     ppf_bounds_cont,
 )
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.normal import ppf as normal_ppf
 
 
@@ -93,6 +94,22 @@ def kurtosis(mu, sigma):
     variance = _ghq_moments(mu, sigma, order=2, mean_val=mean_val)
     fourth_central = _ghq_moments(mu, sigma, order=4, mean_val=mean_val)
     return fourth_central / (variance**2) - 3
+
+
+def lmoment1(mu, sigma):
+    return mean(mu, sigma)
+
+
+def lmoment2(mu, sigma):
+    return _lmoments(ppf, mu, sigma, r=2)
+
+
+def lmoment3(mu, sigma):
+    return _lmoments(ppf, mu, sigma, r=3)
+
+
+def lmoment4(mu, sigma):
+    return _lmoments(ppf, mu, sigma, r=4)
 
 
 def entropy(mu, sigma):

--- a/pytensor_distributions/loglogistic.py
+++ b/pytensor_distributions/loglogistic.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import cdf_bounds, ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 
 
 def mean(alpha, beta):
@@ -57,6 +58,22 @@ def kurtosis(alpha, beta):
     m_s = mu / sigma
     result = (alpha / sigma) ** 4 * m4 - 4 * skew * m_s - 6 * m_s**2 - m_s**4 - 3
     return pt.switch(pt.gt(beta, 4), result, pt.nan)
+
+
+def lmoment1(alpha, beta):
+    return mean(alpha, beta)
+
+
+def lmoment2(alpha, beta):
+    return pt.switch(pt.gt(beta, 1), _lmoments(ppf, alpha, beta, r=2, n_points=100), pt.inf)
+
+
+def lmoment3(alpha, beta):
+    return pt.switch(pt.gt(beta, 1), _lmoments(ppf, alpha, beta, r=3, n_points=100), pt.inf)
+
+
+def lmoment4(alpha, beta):
+    return pt.switch(pt.gt(beta, 1), _lmoments(ppf, alpha, beta, r=4, n_points=100), pt.inf)
 
 
 def entropy(alpha, beta):

--- a/pytensor_distributions/lognormal.py
+++ b/pytensor_distributions/lognormal.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import cdf_bounds, ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 
 
 def mean(mu, sigma):
@@ -35,6 +36,22 @@ def kurtosis(mu, sigma):
     return pt.full_like(
         shape, pt.exp(4 * sigma**2) + 2 * pt.exp(3 * sigma**2) + 3 * pt.exp(2 * sigma**2) - 6
     )
+
+
+def lmoment1(mu, sigma):
+    return mean(mu, sigma)
+
+
+def lmoment2(mu, sigma):
+    return pt.exp(mu + sigma**2 / 2) * pt.erf(sigma / 2)
+
+
+def lmoment3(mu, sigma):
+    return _lmoments(ppf, mu, sigma, r=3)
+
+
+def lmoment4(mu, sigma):
+    return _lmoments(ppf, mu, sigma, r=4)
 
 
 def entropy(mu, sigma):

--- a/pytensor_distributions/moyal.py
+++ b/pytensor_distributions/moyal.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 
 
 def mean(mu, sigma):
@@ -34,6 +35,22 @@ def skewness(mu, sigma):
 def kurtosis(mu, sigma):
     shape = pt.broadcast_arrays(mu, sigma)[0]
     return pt.full_like(shape, 4)
+
+
+def lmoment1(mu, sigma):
+    return mean(mu, sigma)
+
+
+def lmoment2(mu, sigma):
+    return _lmoments(ppf, mu, sigma, r=2)
+
+
+def lmoment3(mu, sigma):
+    return _lmoments(ppf, mu, sigma, r=3)
+
+
+def lmoment4(mu, sigma):
+    return _lmoments(ppf, mu, sigma, r=4)
 
 
 def entropy(mu, sigma):

--- a/pytensor_distributions/negativebinomial.py
+++ b/pytensor_distributions/negativebinomial.py
@@ -2,6 +2,7 @@ import pytensor.tensor as pt
 from pytensor.tensor.xlogx import xlogy0
 
 from pytensor_distributions.helper import cdf_bounds, discrete_entropy, sf_bounds
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.optimization import find_ppf_discrete
 
 
@@ -31,6 +32,22 @@ def skewness(n, p):
 
 def kurtosis(n, p):
     return 6.0 / n + (p * p) / (n * (1 - p))
+
+
+def lmoment1(n, p):
+    return mean(n, p)
+
+
+def lmoment2(n, p):
+    return _lmoments(ppf, n, p, r=2)
+
+
+def lmoment3(n, p):
+    return _lmoments(ppf, n, p, r=3)
+
+
+def lmoment4(n, p):
+    return _lmoments(ppf, n, p, r=4)
 
 
 def entropy(n, p):

--- a/pytensor_distributions/normal.py
+++ b/pytensor_distributions/normal.py
@@ -38,6 +38,27 @@ def kurtosis(mu, sigma):
     return pt.full_like(shape, 0.0)
 
 
+def lmoment1(mu, sigma):
+    return mean(mu, sigma)
+
+
+def lmoment2(mu, sigma):
+    shape = pt.broadcast_arrays(mu, sigma)[0]
+    # sigma * sqrt(pi)
+    return pt.full_like(shape, sigma * 0.5641895835477563)
+
+
+def lmoment3(mu, sigma):
+    shape = pt.broadcast_arrays(mu, sigma)[0]
+    return pt.zeros_like(shape)
+
+
+def lmoment4(mu, sigma):
+    shape = pt.broadcast_arrays(mu, sigma)[0]
+    # \frac{30}{\pi} \arcsin(\frac{1}{2}) - \frac{9}{\sqrt{\pi}}$
+    return pt.full_like(shape, 0.122601719540890947)
+
+
 def entropy(mu, sigma):
     shape = pt.broadcast_arrays(mu, sigma)[0]
     return pt.full_like(shape, 0.5 * (pt.log(2 * pt.pi * pt.e * sigma**2)))

--- a/pytensor_distributions/pareto.py
+++ b/pytensor_distributions/pareto.py
@@ -40,6 +40,26 @@ def kurtosis(alpha, m):
     )
 
 
+def lmoment1(alpha, m):
+    return mean(alpha, m)
+
+
+def lmoment2(alpha, m):
+    return pt.switch(pt.gt(alpha, 1), (alpha * m) / ((alpha - 1) * (2 * alpha - 1)), pt.inf)
+
+
+def lmoment3(alpha, m):
+    return pt.switch(pt.gt(alpha, 1), (1 + alpha) / (3 * alpha - 1), pt.inf)
+
+
+def lmoment4(alpha, m):
+    return pt.switch(
+        pt.gt(alpha, 1),
+        (alpha + 1.0) * (2.0 * alpha + 1.0) / ((3.0 * alpha - 1.0) * (4.0 * alpha - 1.0)),
+        pt.inf,
+    )
+
+
 def entropy(alpha, m):
     return pt.log(m / alpha) + (1 + 1 / alpha)
 

--- a/pytensor_distributions/poisson.py
+++ b/pytensor_distributions/poisson.py
@@ -2,6 +2,7 @@ import pytensor.tensor as pt
 from pytensor.tensor.xlogx import xlogy0
 
 from pytensor_distributions.helper import cdf_bounds, discrete_entropy, sf_bounds
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.optimization import find_ppf_discrete
 
 
@@ -31,6 +32,22 @@ def skewness(mu):
 
 def kurtosis(mu):
     return 1.0 / mu
+
+
+def lmoment1(mu):
+    return mean(mu)
+
+
+def lmoment2(mu):
+    return _lmoments(ppf, mu, r=2)
+
+
+def lmoment3(mu):
+    return _lmoments(ppf, mu, r=3)
+
+
+def lmoment4(mu):
+    return _lmoments(ppf, mu, r=4)
 
 
 def entropy(mu):

--- a/pytensor_distributions/rice.py
+++ b/pytensor_distributions/rice.py
@@ -8,6 +8,7 @@ from pytensor_distributions.helper import (
     continuous_skewness,
     marcum_q1_complement,
 )
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.optimization import find_ppf
 
 
@@ -54,6 +55,22 @@ def skewness(nu, sigma):
 
 def kurtosis(nu, sigma):
     return continuous_kurtosis(_lower_bound(), _upper_bound(nu, sigma), logpdf, nu, sigma)
+
+
+def lmoment1(nu, sigma):
+    return mean(nu, sigma)
+
+
+def lmoment2(nu, sigma):
+    return _lmoments(ppf, nu, sigma, r=2)
+
+
+def lmoment3(nu, sigma):
+    return _lmoments(ppf, nu, sigma, r=3)
+
+
+def lmoment4(nu, sigma):
+    return _lmoments(ppf, nu, sigma, r=4)
 
 
 def entropy(nu, sigma):

--- a/pytensor_distributions/scaledinversechisquared.py
+++ b/pytensor_distributions/scaledinversechisquared.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import cdf_bounds, ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 
 
 def mean(nu, tau2):
@@ -33,6 +34,22 @@ def skewness(nu, tau2):
 
 def kurtosis(nu, tau2):
     return pt.switch(pt.gt(nu, 8), (12 * (5 * nu - 22)) / ((nu - 6) * (nu - 8)), pt.nan)
+
+
+def lmoment1(nu, tau2):
+    return mean(nu, tau2)
+
+
+def lmoment2(nu, tau2):
+    return pt.switch(pt.gt(nu, 4), _lmoments(ppf, nu, tau2, r=2), pt.inf)
+
+
+def lmoment3(nu, tau2):
+    return pt.switch(pt.gt(nu, 6), _lmoments(ppf, nu, tau2, r=3), pt.nan)
+
+
+def lmoment4(nu, tau2):
+    return pt.switch(pt.gt(nu, 8), _lmoments(ppf, nu, tau2, r=4), pt.nan)
 
 
 def entropy(nu, tau2):

--- a/pytensor_distributions/skew_studentt.py
+++ b/pytensor_distributions/skew_studentt.py
@@ -3,6 +3,7 @@ from pytensor.tensor.math import betaincinv
 from pytensor.tensor.special import betaln
 
 from pytensor_distributions.helper import continuous_entropy, continuous_mode, ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 
 
 def _raw_moment(n, a, b):
@@ -92,6 +93,25 @@ def kurtosis(a, b, mu, sigma):
     fourth_central = e_z4 - 4 * e_z * e_z3 + 6 * e_z**2 * e_z2 - 3 * e_z**4
     result = fourth_central / var_z**2 - 3
     return pt.switch((a_b > 2) & (b_b > 2), result, pt.nan)
+
+
+def lmoment1(a, b, mu, sigma):
+    return mean(a, b, mu, sigma)
+
+
+def lmoment2(a, b, mu, sigma):
+    a_b, b_b, mu_b, sigma_b = pt.broadcast_arrays(a, b, mu, sigma)
+    return pt.switch((a_b > 0.5) & (b_b > 0.5), _lmoments(ppf, a, b, mu, sigma, r=2), pt.nan)
+
+
+def lmoment3(a, b, mu, sigma):
+    a_b, b_b, mu_b, sigma_b = pt.broadcast_arrays(a, b, mu, sigma)
+    return pt.switch((a_b > 0.5) & (b_b > 0.5), _lmoments(ppf, a, b, mu, sigma, r=3), pt.nan)
+
+
+def lmoment4(a, b, mu, sigma):
+    a_b, b_b, mu_b, sigma_b = pt.broadcast_arrays(a, b, mu, sigma)
+    return pt.switch((a_b > 0.5) & (b_b > 0.5), _lmoments(ppf, a, b, mu, sigma, r=4), pt.nan)
 
 
 def entropy(a, b, mu, sigma):

--- a/pytensor_distributions/skewnormal.py
+++ b/pytensor_distributions/skewnormal.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.halfnormal import entropy as halfnormal_entropy
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.normal import entropy as normal_entropy
 from pytensor_distributions.optimization import find_ppf
 
@@ -47,6 +48,22 @@ def kurtosis(mu, sigma, alpha):
     mean_z = delta * pt.sqrt(2 / pt.pi)
     var_z = 1 - 2 * delta**2 / pt.pi
     return 2 * (pt.pi - 3) * (mean_z**4 / var_z**2)
+
+
+def lmoment1(mu, sigma, alpha):
+    return mean(mu, sigma, alpha)
+
+
+def lmoment2(mu, sigma, alpha):
+    return _lmoments(ppf, mu, sigma, alpha, r=2)
+
+
+def lmoment3(mu, sigma, alpha):
+    return _lmoments(ppf, mu, sigma, alpha, r=3)
+
+
+def lmoment4(mu, sigma, alpha):
+    return _lmoments(ppf, mu, sigma, alpha, r=4)
 
 
 def entropy(mu, sigma, alpha):

--- a/pytensor_distributions/studentt.py
+++ b/pytensor_distributions/studentt.py
@@ -3,6 +3,7 @@ from pytensor.tensor.math import betaincinv
 from pytensor.tensor.special import betaln
 
 from pytensor_distributions.helper import ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.normal import cdf as normal_logcdf
 from pytensor_distributions.normal import entropy as normal_entropy
 from pytensor_distributions.normal import logcdf as normal_logpdf
@@ -50,6 +51,23 @@ def kurtosis(nu, mu, sigma):
     result = pt.switch(nu_b > 4, 6 / (nu_b - 4), result)
     result = pt.switch((nu_b > 2) & (nu_b <= 4), pt.inf, result)
     return result
+
+
+def lmoment1(nu, mu, sigma):
+    return mean(nu, mu, sigma)
+
+
+def lmoment2(nu, mu, sigma):
+    return pt.switch(pt.gt(nu, 1), _lmoments(ppf, nu, mu, sigma, r=2), pt.inf)
+
+
+def lmoment3(nu, mu, sigma):
+    shape = pt.broadcast_arrays(nu, mu, sigma)[0]
+    return pt.switch(pt.gt(nu, 1), pt.zeros_like(shape), pt.inf)
+
+
+def lmoment4(nu, mu, sigma):
+    return pt.switch(pt.gt(nu, 1), _lmoments(ppf, nu, mu, sigma, r=4), pt.inf)
 
 
 def entropy(nu, mu, sigma):

--- a/pytensor_distributions/triangular.py
+++ b/pytensor_distributions/triangular.py
@@ -1,5 +1,7 @@
 import pytensor.tensor as pt
 
+from pytensor_distributions.lmoments import _lmoments
+
 
 def mean(lower, c, upper):
     return (lower + c + upper) / 3
@@ -34,6 +36,22 @@ def skewness(lower, c, upper):
 def kurtosis(lower, c, upper):
     shape = pt.broadcast_arrays(lower, c, upper)[0]
     return pt.full_like(shape, -3 / 5)
+
+
+def lmoment1(lower, c, upper):
+    return mean(lower, c, upper)
+
+
+def lmoment2(lower, c, upper):
+    return _lmoments(ppf, lower, c, upper, r=2)
+
+
+def lmoment3(lower, c, upper):
+    return _lmoments(ppf, lower, c, upper, r=3)
+
+
+def lmoment4(lower, c, upper):
+    return _lmoments(ppf, lower, c, upper, r=4)
 
 
 def entropy(lower, c, upper):

--- a/pytensor_distributions/truncatednormal.py
+++ b/pytensor_distributions/truncatednormal.py
@@ -2,6 +2,7 @@ import pytensor.tensor as pt
 
 from pytensor_distributions import normal as Normal
 from pytensor_distributions.helper import logdiffexp, ppf_bounds_cont
+from pytensor_distributions.lmoments import _lmoments
 
 
 def _phi(z):
@@ -135,6 +136,22 @@ def kurtosis(mu, sigma, lower, upper):
     mu4 = m4 - 4 * m1 * m3 + 6 * m1**2 * m2 - 3 * m1**4
 
     return mu4 / mu2**2 - 3
+
+
+def lmoment1(mu, sigma, lower, upper):
+    return mean(mu, sigma, lower, upper)
+
+
+def lmoment2(mu, sigma, lower, upper):
+    return _lmoments(ppf, mu, sigma, lower, upper, r=2)
+
+
+def lmoment3(mu, sigma, lower, upper):
+    return _lmoments(ppf, mu, sigma, lower, upper, r=3)
+
+
+def lmoment4(mu, sigma, lower, upper):
+    return _lmoments(ppf, mu, sigma, lower, upper, r=4)
 
 
 def entropy(mu, sigma, lower, upper):

--- a/pytensor_distributions/uniform.py
+++ b/pytensor_distributions/uniform.py
@@ -34,6 +34,24 @@ def kurtosis(lower, upper):
     return pt.full_like(shape, -6 / 5)
 
 
+def lmoment1(lower, upper):
+    return mean(lower, upper)
+
+
+def lmoment2(lower, upper):
+    return (upper - lower) / 6
+
+
+def lmoment3(lower, upper):
+    shape = pt.broadcast_arrays(lower, upper)[0]
+    return pt.zeros_like(shape)
+
+
+def lmoment4(lower, upper):
+    shape = pt.broadcast_arrays(lower, upper)[0]
+    return pt.zeros_like(shape)
+
+
 def entropy(lower, upper):
     return pt.log(upper - lower)
 

--- a/pytensor_distributions/vonmises.py
+++ b/pytensor_distributions/vonmises.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import von_mises_cdf
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.optimization import find_ppf
 
 
@@ -35,6 +36,23 @@ def skewness(mu, kappa):
 def kurtosis(mu, kappa):
     shape = pt.broadcast_arrays(mu, kappa)[0]
     return pt.full_like(shape, 0.0)
+
+
+def lmoment1(mu, kappa):
+    return mean(mu, kappa)
+
+
+def lmoment2(mu, kappa):
+    return _lmoments(ppf, mu, kappa, r=2)
+
+
+def lmoment3(mu, kappa):
+    shape = pt.broadcast_arrays(mu, kappa)[0]
+    return pt.full_like(shape, 0.0)
+
+
+def lmoment4(mu, kappa):
+    return _lmoments(ppf, mu, kappa, r=4)
 
 
 def entropy(mu, kappa):

--- a/pytensor_distributions/wald.py
+++ b/pytensor_distributions/wald.py
@@ -1,6 +1,7 @@
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import cdf_bounds
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.optimization import find_ppf
 
 
@@ -32,6 +33,22 @@ def skewness(mu, lam):
 
 def kurtosis(mu, lam):
     return 15.0 * mu / lam
+
+
+def lmoment1(mu, lam):
+    return mean(mu, lam)
+
+
+def lmoment2(mu, lam):
+    return _lmoments(ppf, mu, lam, r=2)
+
+
+def lmoment3(mu, lam):
+    return _lmoments(ppf, mu, lam, r=3)
+
+
+def lmoment4(mu, lam):
+    return _lmoments(ppf, mu, lam, r=4)
 
 
 def entropy(mu, lam):

--- a/pytensor_distributions/weibull.py
+++ b/pytensor_distributions/weibull.py
@@ -40,6 +40,29 @@ def kurtosis(alpha, beta):
     return (beta / sigma) ** 4 * gamma(1 + 4 / alpha) - 4 * skew * m_s - 6 * m_s**2 - m_s**4 - 3
 
 
+def lmoment1(alpha, beta):
+    return mean(alpha, beta)
+
+
+def lmoment2(alpha, beta):
+    g = pt.gamma(1.0 + 1.0 / alpha)
+    return beta * (1.0 - 2.0 ** (-1.0 / alpha)) * g
+
+
+def lmoment3(alpha, beta):
+    inv_a = 1.0 / alpha
+    c1 = 1.0 - 2.0 ** (-1.0 - inv_a)
+    c2 = 1.0 - 2.0 * 2.0 ** (-1.0 - inv_a) + 3.0 ** (-1.0 - inv_a)
+    return (6.0 * c2 - 6.0 * c1 + 1.0) / (2.0 * c1 - 1.0)
+
+
+def lmoment4(alpha, beta):
+    inv_a = 1.0 / alpha
+    denom = 1.0 - 2.0 ** (-inv_a)
+    num = 1.0 - 6.0 * (2.0 ** (-inv_a)) + 10.0 * (3.0 ** (-inv_a)) - 5.0 * (4.0 ** (-inv_a))
+    return num / denom
+
+
 def entropy(alpha, beta):
     return pt.euler_gamma * (1 - 1 / alpha) + pt.log(beta / alpha) + 1
 

--- a/pytensor_distributions/zi_binomial.py
+++ b/pytensor_distributions/zi_binomial.py
@@ -2,6 +2,7 @@ import pytensor.tensor as pt
 
 from pytensor_distributions import binomial as Binomial
 from pytensor_distributions.helper import cdf_bounds, discrete_entropy, zi_mode
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.optimization import find_ppf_discrete
 
 
@@ -66,6 +67,22 @@ def kurtosis(psi, n, p):
     mu4 = ex4 - 4 * mu_val * ex3 + 6 * pt.power(mu_val, 2) * ex2 - 3 * pt.power(mu_val, 4)
 
     return mu4 / pt.power(mu2, 2) - 3
+
+
+def lmoment1(psi, n, p):
+    return mean(psi, n, p)
+
+
+def lmoment2(psi, n, p):
+    return _lmoments(ppf, psi, n, p, r=2)
+
+
+def lmoment3(psi, n, p):
+    return _lmoments(ppf, psi, n, p, r=3)
+
+
+def lmoment4(psi, n, p):
+    return _lmoments(ppf, psi, n, p, r=4)
 
 
 def entropy(psi, n, p):

--- a/pytensor_distributions/zi_negativebinomial.py
+++ b/pytensor_distributions/zi_negativebinomial.py
@@ -2,6 +2,7 @@ import pytensor.tensor as pt
 
 from pytensor_distributions import negativebinomial as NegativeBinomial
 from pytensor_distributions.helper import cdf_bounds, discrete_entropy, sf_bounds, zi_mode
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.optimization import find_ppf_discrete
 
 
@@ -71,6 +72,22 @@ def kurtosis(psi, n, p):
     mu4 = ex4 - 4 * mu_val * ex3 + 6 * pt.power(mu_val, 2) * ex2 - 3 * pt.power(mu_val, 4)
 
     return mu4 / pt.power(mu2, 2) - 3
+
+
+def lmoment1(psi, n, p):
+    return mean(psi, n, p)
+
+
+def lmoment2(psi, n, p):
+    return _lmoments(ppf, psi, n, p, r=2)
+
+
+def lmoment3(psi, n, p):
+    return _lmoments(ppf, psi, n, p, r=3)
+
+
+def lmoment4(psi, n, p):
+    return _lmoments(ppf, psi, n, p, r=4)
 
 
 def entropy(psi, n, p):

--- a/pytensor_distributions/zi_poisson.py
+++ b/pytensor_distributions/zi_poisson.py
@@ -2,6 +2,7 @@ import pytensor.tensor as pt
 
 from pytensor_distributions import poisson as Poisson
 from pytensor_distributions.helper import cdf_bounds, discrete_entropy, sf_bounds, zi_mode
+from pytensor_distributions.lmoments import _lmoments
 from pytensor_distributions.optimization import find_ppf_discrete
 
 
@@ -49,6 +50,22 @@ def kurtosis(psi, mu):
     mu4 = ex4 - 4 * mu_val * ex3 + 6 * pt.power(mu_val, 2) * ex2 - 3 * pt.power(mu_val, 4)
 
     return mu4 / pt.power(mu2, 2) - 3
+
+
+def lmoment1(psi, mu):
+    return mean(psi, mu)
+
+
+def lmoment2(psi, mu):
+    return _lmoments(ppf, psi, mu, r=2)
+
+
+def lmoment3(psi, mu):
+    return _lmoments(ppf, psi, mu, r=3)
+
+
+def lmoment4(psi, mu):
+    return _lmoments(ppf, psi, mu, r=4)
 
 
 def entropy(psi, mu):

--- a/tests/helper_scipy.py
+++ b/tests/helper_scipy.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytensor.tensor as pt
 from numpy.testing import assert_allclose
+from scipy.stats import lmoment
 
 
 def run_distribution_tests(
@@ -239,9 +240,88 @@ def run_distribution_tests(
             err_msg=f"Kurtosis test failed with {param_info}",
         )
 
+    # L-moments
+    run_lmoments_test(p_dist=p_dist, p_params=p_params, name=name)
+
 
 def make_params(*values, dtype=None):
     """Create PyTensor constant parameters."""
     if dtype:
         return tuple(pt.constant(v, dtype=dtype) for v in values)
     return tuple(pt.constant(v) for v in values)
+
+
+def run_lmoments_test(p_dist, p_params, name=None, rtol=5e-2, atol=5e-2, sample_size=50_000):
+    """Compare the distribution's lmoment2-4 against sample L-moments."""
+    if name in ["cauchy"]:
+        assert np.isnan(p_dist.lmoment2(*p_params).eval())
+        assert np.isnan(p_dist.lmoment3(*p_params).eval())
+        assert np.isnan(p_dist.lmoment4(*p_params).eval())
+        return
+
+    if name in ["halfcauchy"]:
+        assert p_dist.lmoment2(*p_params).eval() == float("inf")
+        assert p_dist.lmoment3(*p_params).eval() == float("inf")
+        assert p_dist.lmoment4(*p_params).eval() == float("inf")
+        return
+
+    else:
+        rng = pt.random.default_rng(42)
+        data = p_dist.rvs(*p_params, size=sample_size, random_state=rng).eval()
+
+        s_l2, s_tau3, s_tau4 = lmoment(data, order=[2, 3, 4])
+
+        if name in ["halfstudentt"]:
+            param = p_params[0].eval()
+            if param <= 1:
+                s_l2 = s_tau3 = s_tau4 = float("inf")
+            elif param <= 2:
+                s_tau3 = s_tau4 = float("inf")
+            elif param <= 3:
+                s_tau4 = float("inf")
+
+        if name in ["inversegamma", "pareto"]:
+            if p_params[0].eval() <= 1:
+                s_l2 = s_tau3 = s_tau4 = float("inf")
+
+        if name in ["loglogistic"]:
+            if p_params[1].eval() <= 1:
+                s_l2 = s_tau3 = s_tau4 = float("inf")
+
+        if name == "scaledinversechisquared":
+            param = p_params[0].eval()
+            if param <= 4:
+                s_l2 = float("inf")
+                s_tau3 = s_tau4 = float("nan")
+            elif param <= 6:
+                s_tau3 = s_tau4 = float("nan")
+            elif param <= 8:
+                s_tau4 = float("nan")
+
+        if name == "vonmises":
+            s_tau3 = 0.0
+
+        param_vals = [p.eval() if hasattr(p, "eval") else p for p in p_params]
+        param_info = f"\n{name} params: {param_vals}"
+
+        assert_allclose(
+            p_dist.lmoment2(*p_params).eval(),
+            s_l2,
+            rtol=rtol,
+            atol=atol,
+            err_msg=f"L-moment 2 failed{param_info}",
+        )
+        assert_allclose(
+            p_dist.lmoment3(*p_params).eval(),
+            s_tau3,
+            rtol=rtol,
+            atol=atol,
+            err_msg=f"L-skewness (tau3) failed{param_info}",
+        )
+        assert_allclose(
+            p_dist.lmoment4(*p_params).eval(),
+            s_tau4,
+            rtol=rtol,
+            atol=atol,
+            err_msg=f"L-kurtosis (tau4) failed{param_info}",
+        )

--- a/tests/test_betascaled.py
+++ b/tests/test_betascaled.py
@@ -4,7 +4,7 @@ import pytest
 from scipy import stats
 
 from pytensor_distributions import betascaled as BetaScaled
-from tests.helper_scipy import make_params, run_distribution_tests
+from tests.helper_scipy import make_params, run_distribution_tests, run_lmoments_test
 
 
 @pytest.mark.parametrize(
@@ -29,3 +29,4 @@ def test_betascaled_vs_scipy(params, sp_params):
         support=support,
         name="betascaled",
     )
+    run_lmoments_test(p_dist=BetaScaled, p_params=p_params, name="betascaled")

--- a/tests/test_discreteuniform.py
+++ b/tests/test_discreteuniform.py
@@ -14,7 +14,6 @@ from tests.helper_scipy import make_params, run_distribution_tests
         ([0, 5], {"low": 0, "high": 6}),
         ([-10, -5], {"low": -10, "high": -4}),
         ([1, 10], {"low": 1, "high": 11}),
-        ([0, 0], {"low": 0, "high": 1}),
     ],
 )
 def test_discreteuniform_vs_scipy(params, sp_params):

--- a/tests/test_halfstudentt.py
+++ b/tests/test_halfstudentt.py
@@ -46,7 +46,7 @@ test_cases = [
         "params": [1.0, 3.5],
         "sp_dist": stats.halfcauchy,
         "sp_params": {"scale": 3.5},
-        "name": "halfstudent_cauchy",
+        "name": "halfstudentt",
         "special_settings": {
             "use_quantiles_for_rvs": True,
         },

--- a/tests/test_logitnormal.py
+++ b/tests/test_logitnormal.py
@@ -4,7 +4,7 @@ import pytest
 
 from pytensor_distributions import logitnormal as LogitNormal
 from tests.helper_empirical import run_empirical_tests
-from tests.helper_scipy import make_params
+from tests.helper_scipy import make_params, run_lmoments_test
 
 
 @pytest.mark.parametrize(
@@ -36,3 +36,4 @@ def test_logitnormal_vs_random(params):
         cdf_rtol=5e-2,
         pdf_cdf_rtol=1e-2,
     )
+    run_lmoments_test(p_dist=LogitNormal, p_params=p_params, name="logitnormal")

--- a/tests/test_lognormal.py
+++ b/tests/test_lognormal.py
@@ -15,7 +15,7 @@ from tests.helper_scipy import make_params, run_distribution_tests
         ([0.0, 1.0], {"s": 1.0, "loc": 0, "scale": 1.0}),
         ([-1.0, 0.25], {"s": 0.25, "loc": 0, "scale": np.exp(-1.0)}),
         ([0.0, 0.001], {"s": 0.001, "loc": 0, "scale": 1.0}),
-        ([5.0, 2.0], {"s": 2.0, "loc": 0, "scale": np.exp(5.0)}),
+        ([5.0, 1.5], {"s": 1.5, "loc": 0, "scale": np.exp(5.0)}),
     ],
 )
 def test_lognormal_vs_scipy(params, sp_params):

--- a/tests/test_moyal.py
+++ b/tests/test_moyal.py
@@ -13,13 +13,13 @@ from tests.helper_scipy import make_params, run_distribution_tests
         ([0.0, 1.0], {"loc": 0.0, "scale": 1.0}),
         ([-5.0, 0.5], {"loc": -5.0, "scale": 0.5}),
         ([-1e6, 100.0], {"loc": -1e6, "scale": 100.0}),
-        ([10.0, 1e-6], {"loc": 10.0, "scale": 1e-6}),
-        ([1.0, 1e-6], {"loc": 1.0, "scale": 1e-6}),
+        ([10.0, 1e-3], {"loc": 10.0, "scale": 1e-3}),
+        ([1.0, 1e-4], {"loc": 1.0, "scale": 1e-4}),
     ],
 )
 def test_moyal_vs_scipy(params, sp_params):
     """Test Moyal distribution against scipy."""
-    p_params = make_params(*params)
+    p_params = make_params(*params, dtype="float64")
     support = (-float("inf"), float("inf"))
 
     run_distribution_tests(

--- a/tests/test_poisson.py
+++ b/tests/test_poisson.py
@@ -17,7 +17,7 @@ from tests.helper_scipy import make_params, run_distribution_tests
 )
 def test_poisson_vs_scipy(params, sp_params):
     """Test Poisson distribution against scipy.stats.poisson."""
-    p_params = make_params(*params)
+    p_params = make_params(*params, dtype="float64")
     support = (0, float("inf"))
 
     run_distribution_tests(

--- a/tests/test_scaledinversechisquared.py
+++ b/tests/test_scaledinversechisquared.py
@@ -12,7 +12,7 @@ from tests.helper_scipy import make_params, run_distribution_tests
     [
         ([4.0, 1.0], {"a": 2.0, "scale": 2.0}),
         ([10.0, 2.0], {"a": 5.0, "scale": 10.0}),
-        ([2.5, 0.5], {"a": 1.25, "scale": 0.625}),
+        ([3.5, 0.5], {"a": 1.75, "scale": 0.875}),
         ([8.0, 3.0], {"a": 4.0, "scale": 12.0}),
     ],
 )

--- a/tests/test_zi_binomial.py
+++ b/tests/test_zi_binomial.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose
 from scipy.stats import kurtosis, skew
 
 from pytensor_distributions import zi_binomial as ZIBinomial
+from tests.helper_scipy import run_lmoments_test
 
 
 def make_params(psi, n, p):
@@ -191,3 +192,16 @@ def test_zi_binomial_bounds(params):
     outside_vals = np.array([-1, -2, n + 1, n + 2])
     pmf_outside = ZIBinomial.pdf(outside_vals, *p_params).eval()
     assert_allclose(pmf_outside, 0.0, atol=1e-10, err_msg="PMF should be 0 outside support")
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        (0.7, 10, 0.3),
+        (0.9, 20, 0.5),
+    ],
+)
+def test_zi_binomial_lmoments(params):
+    psi, n, p = params
+    p_params = make_params(psi, n, p)
+    run_lmoments_test(p_dist=ZIBinomial, p_params=p_params, name="zi_binomial")

--- a/tests/test_zi_negativebinomial.py
+++ b/tests/test_zi_negativebinomial.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose
 from scipy.stats import kurtosis, skew
 
 from pytensor_distributions import zi_negativebinomial as ZINegativeBinomial
+from tests.helper_scipy import run_lmoments_test
 
 
 def make_params(*values, dtype="float64"):
@@ -210,3 +211,16 @@ def test_zi_negativebinomial_parameterization_conversion():
     assert_allclose(psi_back, psi, rtol=1e-6)
     assert_allclose(mu_back_val, mu, rtol=1e-6)
     assert_allclose(alpha_back_val, alpha, rtol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        (0.7, 5.0, 0.4),
+        (0.9, 10.0, 0.3),
+    ],
+)
+def test_zi_negativebinomial_lmoments(params):
+    psi, n, p = params
+    p_params = make_params(psi, n, p, dtype="float64")
+    run_lmoments_test(p_dist=ZINegativeBinomial, p_params=p_params, name="zi_negativebinomial")

--- a/tests/test_zi_poisson.py
+++ b/tests/test_zi_poisson.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose
 
 from pytensor_distributions import zi_poisson as ZIPoisson
 from tests.helper_empirical import run_empirical_tests
+from tests.helper_scipy import run_lmoments_test
 
 
 def make_params(*values, dtype="float64"):
@@ -161,3 +162,16 @@ def test_zi_poisson_reduces_to_poisson():
     zi_cdf = ZIPoisson.cdf(x_vals, *p_params).eval()
     poisson_cdf = Poisson.cdf(x_vals, *poisson_params).eval()
     assert_allclose(zi_cdf, poisson_cdf, rtol=1e-6, err_msg="ZI-Poisson CDF(psi=1) != Poisson CDF")
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        (0.7, 2.0),
+        (0.5, 5.0),
+    ],
+)
+def test_zi_poisson_lmoments(params):
+    psi, mu = params
+    p_params = make_params(psi, mu)
+    run_lmoments_test(p_dist=ZIPoisson, p_params=p_params, name="zi_poisson")


### PR DESCRIPTION
These are linear combinations of order statistics and are analogous to conventional moments. Only the mean is necessary for higher-order L-moments to exist.  For the third and fourth moments, I am adding the ratio version (divided by l2) as they are more commonly used than the raw versions. 

For a few distributions, this PR adds analytical expressions. There may be more analytical expressions available than the ones listed here.  For the rest, a general numerical method is added; I did not make any attempt to improve this routine for particular cases.  