### PR TITLE
Fix AsymmetricLaplace median at kappa=1 (dtype-aware)

### DIFF
--- a/pytensor_distributions/asymmetriclaplace.py
+++ b/pytensor_distributions/asymmetriclaplace.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytensor.tensor as pt
 
 from pytensor_distributions.helper import ppf_bounds_cont
@@ -13,10 +14,16 @@ def mode(mu, b, kappa):
 
 
 def median(mu, b, kappa):
+    # Writing log((1 + kappa**2) / 2) directly lets PyTensor rewrite it through an
+    # imprecise log(2) constant, so the median isn't exact at kappa == 1. Use log1p
+    # with a log(2) cast to the input dtype, which cancels exactly in any dtype.
+    log1p_k2 = pt.log1p(kappa**2)
+    log1p_inv_k2 = pt.log1p(1 / kappa**2)  # 1 / kappa**2 stays <= 1, avoiding overflow
+    log2 = np.asarray(np.log(2.0), dtype=log1p_k2.dtype)
     return pt.switch(
         pt.gt(kappa, 1),
-        mu + kappa * b * pt.log((1 + kappa**2) / (2 * kappa**2)),
-        mu - pt.log((1 + kappa**2) / 2) / (kappa / b),
+        mu + kappa * b * (log1p_inv_k2 - log2),  # log((1 + kappa**2) / (2 * kappa**2))
+        mu - (b / kappa) * (log1p_k2 - log2),  # log((1 + kappa**2) / 2)
     )
 
 

--- a/tests/test_asymmetriclaplace.py
+++ b/tests/test_asymmetriclaplace.py
@@ -1,5 +1,7 @@
 """Test AsymmetricLaplace distribution against scipy implementation."""
 
+import numpy as np
+import pytensor.tensor as pt
 import pytest
 from scipy import stats
 
@@ -29,3 +31,17 @@ def test_asymmetriclaplace_vs_scipy(params, sp_params):
         support=support,
         name="asymmetriclaplace",
     )
+
+
+@pytest.mark.parametrize("dtype", ["float64", "float32"])
+def test_median_symmetric_is_exact_and_dtype_preserving(dtype):
+    """At kappa=1 (symmetric Laplace) the median is exactly the location, in any dtype.
+
+    Guards the dtype-aware log(2) constant: a float64 constant would upcast float32
+    inputs and leave a ~1.9e-9 residual instead of an exact 0.
+    """
+    mu, b, kappa = (pt.constant(v, dtype=dtype) for v in (3.0, 2.0, 1.0))
+    median = AsymmetricLaplace.median(mu, b, kappa)
+
+    assert median.dtype == dtype
+    np.testing.assert_array_equal(median.eval(), np.asarray(3.0, dtype=dtype))


### PR DESCRIPTION
## Problem

For `AsymmetricLaplace(loc=0, scale=1, kappa=1)` — the symmetric Laplace, whose median is exactly `mu = 0` — `median` returns `≈1.9e-9`, failing the suite's exact (`atol=1e-15`) check against scipy's `0.0`:

```
Median test failed
Max absolute difference among violations: 1.90465432e-09
Max relative difference among violations: inf
```

## Root cause

The `kappa <= 1` branch computes `pt.log((1 + kappa**2) / 2)`, which PyTensor rewrites to `log1p(kappa**2) - 0.6931471824645996` — that constant is `log(2)` truncated to **float32** (true `log(2) = 0.6931471805599453`). At `kappa = 1`, `log1p(1.0) - 0.6931471824645996 = -1.9e-9`. The error grows near `kappa = 1` (relerr `~1.9e-3` at `kappa = 0.999999`). This is an upstream PyTensor rewrite bug (`local_log_div` folds `log(2)` at float32 precision): pymc-devs/pytensor#2244.

## Fix

Spell each branch as `log1p(<= 1) - log(2)`, with `log(2)` cast to the input dtype:

```
kappa <= 1:  log((1 + kappa**2) / 2)           = log1p(kappa**2)   - log(2)
kappa  > 1:  log((1 + kappa**2) / (2*kappa**2)) = log1p(1/kappa**2) - log(2)
```

- **Exact at `kappa = 1`** (`log1p(1) - log(2) = 0`).
- **Overflow-safe** — each `log1p` argument is `<= 1`; bare `kappa**2` overflows for `kappa > ~1.3e154` (→ `nan`).
- **dtype-aware** — a float64 `log(2)` upcasts float32 inputs *and* reintroduces the residual; casting via `np.asarray(np.log(2.0), dtype=...)` keeps float32 exact and dtype-preserving, mirroring genpareto's `_log1p_div`/`_expm1_div` (#53).

## Verification

Against a 60-digit mpmath reference over `kappa ∈ [1e-15, 1e300]` and extreme `mu`/`b`:

| | original | fix |
|---|---|---|
| worst relerr, `kappa ∈ [1e-15, 1e15]` | ~1900 near `kappa=1` | `1e-9` |
| `kappa = 1` (float64 & float32) | `1.9e-9` (fails) | exact `0` |
| `kappa > 1.3e154` | `inf`/`nan` | finite, correct |
| float32 output dtype | upcast to float64 | preserved |

Adds a `float32`/`float64` regression test for the symmetric-point value and dtype. Suite: 1 failed → 6 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
